### PR TITLE
Support multiple extension versions in V5 extrinsics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog].
 ## 0.4.0 (2024-10-21)
 
 - Split `ExtrinsicTypeInfo` trait to get signature and extensions info separately, and support being given an extension version in the latter.
-- Remove support for V5 signed extrinsics, which are no longer a thing.
+- Remove support for V5 signed extrinsics, which are no longer a thing (see [#3685](https://github.com/paritytech/polkadot-sdk/pull/3685) for context).
 
 ## 0.3.0 (2024-09-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.4.0 (2024-10-21)
+
+- Split `ExtrinsicTypeInfo` trait to get signature and extensions info separately, and support being given an extension version in the latter.
+- Remove support for V5 signed extrinsics, which are no longer a thing.
+
 ## 0.3.0 (2024-09-30)
 
 - Fix `extrinsic.call_range()` and `extensions.range()` functions, and clarify descriptions. 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "frame-decode"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "frame-metadata 16.0.0",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"

--- a/src/decoding/extrinsic_decoder.rs
+++ b/src/decoding/extrinsic_decoder.rs
@@ -623,9 +623,7 @@ where
     let extensions = (version_ty == ExtrinsicType::General || version_ty == ExtrinsicType::Signed)
         .then(|| {
             // For v5 "General" extrinsics, there is a transaction extensions version byte, too.
-            let transaction_extensions_version = if version_ty == ExtrinsicType::General
-                && version == 5
-            {
+            let transaction_extensions_version = if version_ty == ExtrinsicType::General {
                 u8::decode(cursor).map_err(ExtrinsicDecodeError::CannotDecodeExtensionsVersion)?
             } else {
                 0

--- a/src/decoding/extrinsic_decoder.rs
+++ b/src/decoding/extrinsic_decoder.rs
@@ -624,9 +624,12 @@ where
         .then(|| {
             // For v5 "General" extrinsics, there is a transaction extensions version byte, too.
             let transaction_extensions_version = if version_ty == ExtrinsicType::General {
-                u8::decode(cursor).map_err(ExtrinsicDecodeError::CannotDecodeExtensionsVersion)?
+                Some(
+                    u8::decode(cursor)
+                        .map_err(ExtrinsicDecodeError::CannotDecodeExtensionsVersion)?,
+                )
             } else {
-                0
+                None
             };
 
             let extension_info = info
@@ -656,7 +659,7 @@ where
             }
 
             Ok::<_, ExtrinsicDecodeError>(ExtrinsicExtensions {
-                transaction_extensions_version,
+                transaction_extensions_version: transaction_extensions_version.unwrap_or(0),
                 transaction_extensions,
             })
         })

--- a/src/decoding/extrinsic_type_info.rs
+++ b/src/decoding/extrinsic_type_info.rs
@@ -127,10 +127,10 @@ impl<'a> core::fmt::Display for ExtrinsicInfoError<'a> {
                 write!(f, "Could not find the extrinsic signature type.")
             }
             ExtrinsicInfoError::ExtrinsicExtensionVersionNotSupported { extension_version } => {
-                // Dev note: If we see a V5 GEneral extrinsic, it will have a byte for the version of the transaction extensions.
-                // In V15 or below metadata, we don't know which set of transaction extensions we're being told about though. Is it
-                // the set that corresponds to the version byte we see or not?
-                write!(f, "The extrinsic contains an extension version (here, {extension_version}), but in metadata <=V15 it's not clear if we can decode this version or not.")
+                // Dev note: If we see a V5 General extrinsic, it will contain a byte for the version of the transaction extensions.
+                // In V15 or below metadata, we don't know which version of the transaction extensions we're being told about. Thus,
+                // We can't be sure that we can decode a given extrinsic with V15 or below metadata.
+                write!(f, "The extrinsic contains an extension version (here, version {extension_version}), but in metadata <=V15 it's not obvious how to decode this.")
             }
             ExtrinsicInfoError::ExtrinsicExtensionVersionNotFound { extension_version } => {
                 write!(f, "Could not find information about extensions with version {extension_version} in the metadata. Note: Metadata <=V15 only supports version 0.")

--- a/src/decoding/extrinsic_type_info.rs
+++ b/src/decoding/extrinsic_type_info.rs
@@ -323,7 +323,9 @@ impl ExtrinsicTypeInfo for frame_metadata::v14::RuntimeMetadataV14 {
         extension_version: u8,
     ) -> Result<ExtrinsicExtensionInfo<'_, Self::TypeId>, ExtrinsicInfoError<'_>> {
         if extension_version != 0 {
-            return Err(ExtrinsicInfoError::ExtrinsicExtensionVersionNotFound { extension_version });
+            return Err(ExtrinsicInfoError::ExtrinsicExtensionVersionNotFound {
+                extension_version,
+            });
         }
 
         let extension_ids = self
@@ -362,7 +364,9 @@ impl ExtrinsicTypeInfo for frame_metadata::v15::RuntimeMetadataV15 {
         extension_version: u8,
     ) -> Result<ExtrinsicExtensionInfo<'_, Self::TypeId>, ExtrinsicInfoError<'_>> {
         if extension_version != 0 {
-            return Err(ExtrinsicInfoError::ExtrinsicExtensionVersionNotFound { extension_version });
+            return Err(ExtrinsicInfoError::ExtrinsicExtensionVersionNotFound {
+                extension_version,
+            });
         }
 
         let extension_ids = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ pub mod extrinsics {
         ExtrinsicSignature, ExtrinsicType,
     };
     pub use crate::decoding::extrinsic_type_info::{
-        ExtrinsicInfo, ExtrinsicInfoArg, ExtrinsicInfoError, ExtrinsicSignatureInfo,
-        ExtrinsicTypeInfo,
+        ExtrinsicCallInfo, ExtrinsicExtensionInfo, ExtrinsicInfoArg, ExtrinsicInfoError,
+        ExtrinsicSignatureInfo, ExtrinsicTypeInfo,
     };
 
     /// Decode an extrinsic in a modern runtime (ie one exposing V14+ metadata).


### PR DESCRIPTION
Split the trait to get extrinsic info apart a little so that we can separately get transaction extensions given a version.

Only allow extension version 0 for <V16 metadatas  at the moment. When it's possible for another version to exist, we'll need to tighten up on this and require V16 metadata to decode any verioned extensions properly.

Also remove support for V5 signed extrinsics, since they no longer exist as of the PR merging.

**Testing:** 
- I integrated it into Subxt and tested against a newly build `substrate-node` as well as an older one.
- I updated `polkadot-historic-decoding-example` to check that it could decode V5 txs from the new Substrate node as well as general old/new blocks from polkadot RPCs