### PR TITLE
ci: ignore dependabot patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-ignore:
+    ignore:
       - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
+        update-types: ["version-update:semver-patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"


### PR DESCRIPTION
These patch updates are not useful for a rust library which can still be updated by user of the library.

Critical security release will be updated though, https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/