### PR TITLE
fix: range logic, set `end=start` if end not found

### DIFF
--- a/src/decoding/extrinsic_decoder.rs
+++ b/src/decoding/extrinsic_decoder.rs
@@ -222,7 +222,7 @@ impl<'info, TypeId> Extrinsic<'info, TypeId> {
             .call_data()
             .map(|a| a.range.end as usize)
             .max()
-            .unwrap_or(0);
+            .unwrap_or(start);
 
         Range { start, end }
     }
@@ -235,7 +235,7 @@ impl<'info, TypeId> Extrinsic<'info, TypeId> {
             .call_data()
             .map(|a| a.range.end as usize)
             .max()
-            .unwrap_or(0);
+            .unwrap_or(start);
 
         Range { start, end }
     }
@@ -374,7 +374,11 @@ impl<'info, TypeId> ExtrinsicExtensions<'info, TypeId> {
             .map(|a| a.range.start as usize)
             .min()
             .unwrap_or(0);
-        let end = self.iter().map(|a| a.range.end as usize).max().unwrap_or(0);
+        let end = self
+            .iter()
+            .map(|a| a.range.end as usize)
+            .max()
+            .unwrap_or(start);
 
         Range { start, end }
     }


### PR DESCRIPTION
The call data in an extrinsic could be empty, such as https://polkadot.subscan.io/extrinsic/24413043-3 in such a scenario, the range would be  `start..0` which would panic if that range is used to index in to a slice or something when start > 0