### PR TITLE
Prep for 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+
+## 0.7.1 (2025-04-23)
+
+- Support `frame-metadata` v20-v21.
+
 ## 0.7.0 (2025-03-05)
 
 - Bump `frame-metadata` to latest: 20.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "frame-decode"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "frame-metadata",
  "hex",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26de808fa6461f2485dc51811aefed108850064994fb4a62b3ac21ffa62ac8df"
+checksum = "20dfd1d7eae1d94e32e869e2fb272d81f52dd8db57820a373adb83ea24d7d862"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"
@@ -34,7 +34,7 @@ legacy = [
 ]
 
 [dependencies]
-frame-metadata = { version = "20.0.0", features = ["current"], default-features = false }
+frame-metadata = { version = ">=20.0.0, <=21.0.0", features = ["current"], default-features = false }
 parity-scale-codec = { version = "3.6.12", default-features = false }
 scale-decode = { version = "0.16.0", default-features = false }
 scale-info = { version = "2.11.4", default-features = false }


### PR DESCRIPTION
A new patch release to widen frame-metadata support to v20 and v21 (since the changes have no impact here)