### PR TITLE
Prep for 0.8.0 release with Support V16 metadata and frame-decode@23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.8.0 (2025-05-07)
+
+- Support `frame-metadata` v23. That stabilized V16 metadata, so we implement the relevant traits for that here to support it.
 
 ## 0.7.1 (2025-04-23)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "frame-decode"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "frame-metadata",
  "hex",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "21.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20dfd1d7eae1d94e32e869e2fb272d81f52dd8db57820a373adb83ea24d7d862"
+checksum = "d8c26fcb0454397c522c05fdad5380c4e622f8a875638af33bff5a320d1fc965"
 dependencies = [
  "cfg-if",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"
@@ -34,7 +34,7 @@ legacy = [
 ]
 
 [dependencies]
-frame-metadata = { version = ">=20.0.0, <=21.0.0", features = ["current"], default-features = false }
+frame-metadata = { version = "23.0.0", features = ["current"], default-features = false }
 parity-scale-codec = { version = "3.6.12", default-features = false }
 scale-decode = { version = "0.16.0", default-features = false }
 scale-info = { version = "2.11.4", default-features = false }

--- a/src/decoding/extrinsic_type_info.rs
+++ b/src/decoding/extrinsic_type_info.rs
@@ -418,12 +418,12 @@ impl ExtrinsicTypeInfo for frame_metadata::v16::RuntimeMetadataV16 {
             .extrinsic
             .transaction_extensions_by_version
             .get(&extension_version)
-            .ok_or_else(
-                || ExtrinsicInfoError::ExtrinsicExtensionVersionNotSupported { extension_version },
-            )?;
+            .ok_or(ExtrinsicInfoError::ExtrinsicExtensionVersionNotSupported {
+                extension_version,
+            })?;
 
         let extension_ids = extension_indexes
-            .into_iter()
+            .iter()
             .map(|idx| {
                 let ext = self
                     .extrinsic

--- a/src/decoding/storage_type_info.rs
+++ b/src/decoding/storage_type_info.rs
@@ -181,7 +181,7 @@ pub enum StorageHasher {
     Identity,
 }
 
-macro_rules! impl_storage_type_info_for_v14_to_v15 {
+macro_rules! impl_storage_type_info_for_v14_to_v16 {
     ($path:path, $name:ident, $to_storage_hasher:ident) => {
         const _: () = {
             use $path as path;
@@ -298,15 +298,20 @@ macro_rules! impl_storage_type_info_for_v14_to_v15 {
     };
 }
 
-impl_storage_type_info_for_v14_to_v15!(
+impl_storage_type_info_for_v14_to_v16!(
     frame_metadata::v14,
     RuntimeMetadataV14,
     to_storage_hasher_v14
 );
-impl_storage_type_info_for_v14_to_v15!(
+impl_storage_type_info_for_v14_to_v16!(
     frame_metadata::v15,
     RuntimeMetadataV15,
     to_storage_hasher_v15
+);
+impl_storage_type_info_for_v14_to_v16!(
+    frame_metadata::v16,
+    RuntimeMetadataV16,
+    to_storage_hasher_v16
 );
 
 macro_rules! to_latest_storage_hasher {
@@ -327,6 +332,7 @@ macro_rules! to_latest_storage_hasher {
 
 to_latest_storage_hasher!(to_storage_hasher_v14, frame_metadata::v14::StorageHasher);
 to_latest_storage_hasher!(to_storage_hasher_v15, frame_metadata::v15::StorageHasher);
+to_latest_storage_hasher!(to_storage_hasher_v16, frame_metadata::v16::StorageHasher);
 
 #[cfg(feature = "legacy")]
 mod legacy {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,3 +461,67 @@ pub mod helpers {
     ///
     pub use scale_decode;
 }
+
+#[cfg(test)]
+mod test {
+    use crate::decoding::extrinsic_type_info::ExtrinsicTypeInfo;
+    use crate::decoding::storage_type_info::StorageTypeInfo;
+    use crate::utils::{InfoAndResolver, ToStorageEntriesList, ToTypeRegistry};
+
+    macro_rules! impls_trait {
+        ($type:ty, $trait:path) => {
+            const _: () = {
+                const fn assert_impl<T: $trait>() {}
+                assert_impl::<$type>();
+            };
+        };
+    }
+
+    // Just a sanity check that all of the metadata versions we expect implement
+    // all of the key traits. Makes it harder to miss something when adding a new metadata
+    // version; just add it below and implement the traits until everything compiles.
+    #[rustfmt::skip]
+    const _: () = {
+        impls_trait!(frame_metadata::v14::RuntimeMetadataV14, InfoAndResolver);
+        impls_trait!(frame_metadata::v15::RuntimeMetadataV15, InfoAndResolver);
+        impls_trait!(frame_metadata::v16::RuntimeMetadataV16, InfoAndResolver);
+
+        impls_trait!(frame_metadata::v8::RuntimeMetadataV8, ExtrinsicTypeInfo);
+        impls_trait!(frame_metadata::v9::RuntimeMetadataV9, ExtrinsicTypeInfo);
+        impls_trait!(frame_metadata::v10::RuntimeMetadataV10, ExtrinsicTypeInfo);
+        impls_trait!(frame_metadata::v11::RuntimeMetadataV11, ExtrinsicTypeInfo);
+        impls_trait!(frame_metadata::v12::RuntimeMetadataV12, ExtrinsicTypeInfo);
+        impls_trait!(frame_metadata::v13::RuntimeMetadataV13, ExtrinsicTypeInfo);
+        impls_trait!(frame_metadata::v14::RuntimeMetadataV14, ExtrinsicTypeInfo);
+        impls_trait!(frame_metadata::v15::RuntimeMetadataV15, ExtrinsicTypeInfo);
+        impls_trait!(frame_metadata::v16::RuntimeMetadataV16, ExtrinsicTypeInfo);
+
+        impls_trait!(frame_metadata::v8::RuntimeMetadataV8, StorageTypeInfo);
+        impls_trait!(frame_metadata::v9::RuntimeMetadataV9, StorageTypeInfo);
+        impls_trait!(frame_metadata::v10::RuntimeMetadataV10, StorageTypeInfo);
+        impls_trait!(frame_metadata::v11::RuntimeMetadataV11, StorageTypeInfo);
+        impls_trait!(frame_metadata::v12::RuntimeMetadataV12, StorageTypeInfo);
+        impls_trait!(frame_metadata::v13::RuntimeMetadataV13, StorageTypeInfo);
+        impls_trait!(frame_metadata::v14::RuntimeMetadataV14, StorageTypeInfo);
+        impls_trait!(frame_metadata::v15::RuntimeMetadataV15, StorageTypeInfo);
+        impls_trait!(frame_metadata::v16::RuntimeMetadataV16, StorageTypeInfo);
+
+        impls_trait!(frame_metadata::v8::RuntimeMetadataV8, ToStorageEntriesList);
+        impls_trait!(frame_metadata::v9::RuntimeMetadataV9, ToStorageEntriesList);
+        impls_trait!(frame_metadata::v10::RuntimeMetadataV10, ToStorageEntriesList);
+        impls_trait!(frame_metadata::v11::RuntimeMetadataV11, ToStorageEntriesList);
+        impls_trait!(frame_metadata::v12::RuntimeMetadataV12, ToStorageEntriesList);
+        impls_trait!(frame_metadata::v13::RuntimeMetadataV13, ToStorageEntriesList);
+        impls_trait!(frame_metadata::v14::RuntimeMetadataV14, ToStorageEntriesList);
+        impls_trait!(frame_metadata::v15::RuntimeMetadataV15, ToStorageEntriesList);
+        impls_trait!(frame_metadata::v16::RuntimeMetadataV16, ToStorageEntriesList);
+
+        // This is a legacy trait and so only legacy metadata versions implement it:
+        impls_trait!(frame_metadata::v8::RuntimeMetadataV8, ToTypeRegistry);
+        impls_trait!(frame_metadata::v9::RuntimeMetadataV9, ToTypeRegistry);
+        impls_trait!(frame_metadata::v10::RuntimeMetadataV10, ToTypeRegistry);
+        impls_trait!(frame_metadata::v11::RuntimeMetadataV11, ToTypeRegistry);
+        impls_trait!(frame_metadata::v12::RuntimeMetadataV12, ToTypeRegistry);
+        impls_trait!(frame_metadata::v13::RuntimeMetadataV13, ToTypeRegistry);
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,7 +462,7 @@ pub mod helpers {
     pub use scale_decode;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy"))]
 mod test {
     use crate::decoding::extrinsic_type_info::ExtrinsicTypeInfo;
     use crate::decoding::storage_type_info::StorageTypeInfo;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,6 +24,12 @@ pub use type_registry_from_metadata::{
     type_registry_from_metadata, type_registry_from_metadata_any,
 };
 
+// We don't want to expose these traits at the moment, but want to test them.
+#[cfg(all(test, feature = "legacy"))]
+pub use list_storage_entries::ToStorageEntriesList;
+#[cfg(test)]
+pub use type_registry_from_metadata::ToTypeRegistry;
+
 /// A utility function to unwrap the `DecodeDifferent` enum found in earlier metadata versions.
 #[cfg(feature = "legacy")]
 pub fn as_decoded<A, B>(item: &frame_metadata::decode_different::DecodeDifferent<A, B>) -> &B {
@@ -57,6 +63,18 @@ impl InfoAndResolver for frame_metadata::v14::RuntimeMetadataV14 {
 
 impl InfoAndResolver for frame_metadata::v15::RuntimeMetadataV15 {
     type Info = frame_metadata::v15::RuntimeMetadataV15;
+    type Resolver = scale_info::PortableRegistry;
+
+    fn info(&self) -> &Self::Info {
+        self
+    }
+    fn resolver(&self) -> &Self::Resolver {
+        &self.types
+    }
+}
+
+impl InfoAndResolver for frame_metadata::v16::RuntimeMetadataV16 {
+    type Info = frame_metadata::v16::RuntimeMetadataV16;
     type Resolver = scale_info::PortableRegistry;
 
     fn info(&self) -> &Self::Info {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,7 +27,7 @@ pub use type_registry_from_metadata::{
 // We don't want to expose these traits at the moment, but want to test them.
 #[cfg(all(test, feature = "legacy"))]
 pub use list_storage_entries::ToStorageEntriesList;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy"))]
 pub use type_registry_from_metadata::ToTypeRegistry;
 
 /// A utility function to unwrap the `DecodeDifferent` enum found in earlier metadata versions.

--- a/src/utils/list_storage_entries.rs
+++ b/src/utils/list_storage_entries.rs
@@ -69,8 +69,7 @@ pub fn list_storage_entries_any(
         RuntimeMetadata::V13(_opaque) => Box::new(core::iter::empty()),
         RuntimeMetadata::V14(m) => Box::new(m.storage_entries_list()),
         RuntimeMetadata::V15(m) => Box::new(m.storage_entries_list()),
-        // TODO: support unstable metadata v16 https://github.com/paritytech/frame-decode/issues/11
-        RuntimeMetadata::V16(_opaque) => Box::new(core::iter::empty()),
+        RuntimeMetadata::V16(m) => Box::new(m.storage_entries_list()),
     }
 }
 
@@ -142,7 +141,7 @@ const _: () = {
     impl_storage_entries_list_for_v8_to_v13!(frame_metadata::v13::RuntimeMetadataV13);
 };
 
-macro_rules! impl_storage_entries_list_for_v14_to_v15 {
+macro_rules! impl_storage_entries_list_for_v14_to_v16 {
     ($path:path) => {
         impl ToStorageEntriesList for $path {
             fn storage_entries_list(&self) -> impl Iterator<Item = StorageEntry<'_>> {
@@ -164,8 +163,9 @@ macro_rules! impl_storage_entries_list_for_v14_to_v15 {
     };
 }
 
-impl_storage_entries_list_for_v14_to_v15!(frame_metadata::v14::RuntimeMetadataV14);
-impl_storage_entries_list_for_v14_to_v15!(frame_metadata::v15::RuntimeMetadataV15);
+impl_storage_entries_list_for_v14_to_v16!(frame_metadata::v14::RuntimeMetadataV14);
+impl_storage_entries_list_for_v14_to_v16!(frame_metadata::v15::RuntimeMetadataV15);
+impl_storage_entries_list_for_v14_to_v16!(frame_metadata::v16::RuntimeMetadataV16);
 
 enum Either<L, R> {
     Left(L),


### PR DESCRIPTION
Support `frame-metadata` v23. That stabilized V16 metadata, so we implement the relevant traits for that here to support it.