### PR TITLE
Prep to release 0.8.1 which exposes Polkadot types via API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --all-targets --workspace
+          args: --all-targets --workspace --features legacy-types
 
       - name: Cargo test docs
         uses: actions-rs/cargo@v1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.8.1 (2025-07-15)
+
+- Expose a `crate::legacy_types` module which provides `crate::legacy_types::polkadot::relay_chain()` to access the relay chain types. This is gated behind the "legacy-types" feature which is disabled by default.
+
 ## 0.8.0 (2025-05-07)
 
 - Support `frame-metadata` v23. That stabilized V16 metadata, so we implement the relevant traits for that here to support it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "frame-decode"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "frame-metadata",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"
@@ -33,6 +33,12 @@ legacy = [
     "dep:scale-info-legacy"
 ]
 
+# Provide legacy types.
+legacy-types = [
+    "legacy",
+    "dep:serde_yaml"
+]
+
 [dependencies]
 frame-metadata = { version = "23.0.0", features = ["current"], default-features = false }
 parity-scale-codec = { version = "3.6.12", default-features = false }
@@ -42,6 +48,7 @@ scale-info-legacy = { version = "0.2.2", default-features = false, optional = tr
 scale-type-resolver = "0.2.0"
 scale-value = { version = "0.18.0", default-features = false, optional = true }
 sp-crypto-hashing = { version = "0.1.0", default-features = false }
+serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,6 +434,24 @@ pub mod storage {
     }
 }
 
+#[cfg(feature = "legacy-types")]
+pub mod legacy_types {
+    //! This module contains legacy types that can be used to decode pre-V14 blocks and storage.
+
+    pub mod polkadot {
+        //! Legacy types for Polkadot chains.
+
+        /// Legacy types for the Polkadot Relay Chain.
+        pub fn relay_chain() -> scale_info_legacy::ChainTypeRegistry {
+            // This is a convenience function to load the Polkadot relay chain types.
+            // It is used in the examples in this crate.
+            let bytes = include_bytes!("../types/polkadot_types.yaml");
+            serde_yaml::from_slice(bytes).expect("Polkadot types are valid YAML")
+        }
+    }
+
+}
+
 pub mod helpers {
     //! Helper functions and types to assist with decoding.
     //!
@@ -467,6 +485,13 @@ mod test {
     use crate::decoding::extrinsic_type_info::ExtrinsicTypeInfo;
     use crate::decoding::storage_type_info::StorageTypeInfo;
     use crate::utils::{InfoAndResolver, ToStorageEntriesList, ToTypeRegistry};
+
+    // This will panic if there is any issue decoding the legacy types we provide.
+    #[cfg(all(test, feature = "legacy-types"))]
+    #[test]
+    fn test_deserializing_legacy_types() {
+        let _ = crate::legacy_types::polkadot::relay_chain();
+    }   
 
     macro_rules! impls_trait {
         ($type:ty, $trait:path) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,7 +449,6 @@ pub mod legacy_types {
             serde_yaml::from_slice(bytes).expect("Polkadot types are valid YAML")
         }
     }
-
 }
 
 pub mod helpers {
@@ -491,7 +490,7 @@ mod test {
     #[test]
     fn test_deserializing_legacy_types() {
         let _ = crate::legacy_types::polkadot::relay_chain();
-    }   
+    }
 
     macro_rules! impls_trait {
         ($type:ty, $trait:path) => {


### PR DESCRIPTION
## 0.8.1 (2025-07-15)

- Expose a `crate::legacy_types` module which provides `crate::legacy_types::polkadot::relay_chain()` to access the relay chain types. This is gated behind the "legacy-types" feature which is disabled by default.