### PR TITLE
Prep 0.11.1 release and fix storage info in case of 1 hasher & tuple of keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.11.1 (2025-10-24)
+
+Fix storage info logic in the case of one hasher and a tuple of keys.
+
 ## 0.11.0 (2025-10-08)
 
 This release adds encode/decode logic for Runtime APIs, Constants and Custom Values, and removes some unused bits and pieces. Additionally we merge the trait functions for getting lists of entries into the main `*TypeInfo` traits, and do a little renaming for consistency. See [#46](https://github.com/paritytech/frame-decode/pull/46) for more information.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "frame-decode"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "frame-metadata",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"


### PR DESCRIPTION
This has cropped up before and so a test in Subxt caught it. Storage entries are represented in metadata as:

1. 1 hasher and 1 key type (this means; hash the value for that key type).
2. multiple hashers and a key type which is a tuple (this means; hash each entry in the tuple with each hasher.
3. 1 hasher and a key type which is a tuple (this means the same as (1); hash the value for the whole tuple with the hasher)

The log was previously checking for (2) first, which means that (3) was handled incorrectly. This has been fixed and the Subxt test passes now.

TODO: We should aim to test this logic and others better in this crate if we can.