### PR TITLE
Kusama AH storage types

### DIFF
--- a/types/kusuma_ah_storage_types.yaml
+++ b/types/kusuma_ah_storage_types.yaml
@@ -1,6 +1,5 @@
-# This file provides all the type information necessary to decode historic blocks and storage entries on the 
-# Polkadot relay chain. See https://docs.rs/scale-info-legacy/0.2.0/scale_info_legacy/chain_types/struct.ChainTypeRegistry.html
-# for more information, or check out the documentation for this crate to see example usage.
+# This file provides all the type information necessary to decode storage entries on the 
+# kusama assethub chain. See https://docs.rs/scale-info-legacy/0.2.0/scale_info_legacy/chain_types/struct.ChainTypeRegistry.html
 global:
   types:
     # Babe
@@ -886,9 +885,8 @@ global:
     AssetId: u32
     T::AssetId: AssetId
 forSpec:
-  - range: [1, 2]
+  - range: [1, 3]
     types:
-      # Statemine/AssetHub early runtime uses only Aura session key
       T::Keys: AccountId
   - range: [1, null]
     types:
@@ -975,49 +973,50 @@ forSpec:
       T::StringLimit: u32
       T::KeyLimit: u32
       T::ValueLimit: u32
-#  - range: [23, null]
-#    types:
-#      CompactScoreCompact: (Compact<ValidatorIndex>, Compact<OffchainAccuracy>)
-#      CompactAssignments:
-#        votes1: Vec<(Compact<NominatorIndex>, Compact<ValidatorIndex>)>
-#        votes2: Vec<(Compact<NominatorIndex>, CompactScoreCompact, Compact<ValidatorIndex>)>
-#        votes3: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 2], Compact<ValidatorIndex>)>
-#        votes4: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 3], Compact<ValidatorIndex>)>
-#        votes5: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 4], Compact<ValidatorIndex>)>
-#        votes6: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 5], Compact<ValidatorIndex>)>
-#        votes7: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 6], Compact<ValidatorIndex>)>
-#        votes8: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 7], Compact<ValidatorIndex>)>
-#        votes9: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 8], Compact<ValidatorIndex>)>
-#        votes10: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 9], Compact<ValidatorIndex>)>
-#        votes11: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 10], Compact<ValidatorIndex>)>
-#        votes12: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 11], Compact<ValidatorIndex>)>
-#        votes13: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 12], Compact<ValidatorIndex>)>
-#        votes14: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 13], Compact<ValidatorIndex>)>
-#        votes15: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 14], Compact<ValidatorIndex>)>
-#        votes16: Vec<(Compact<NominatorIndex>, [CompactScoreCompact; 15], Compact<ValidatorIndex>)>
-#  - range: [25, null]
-#    types:
-#      RefCount: u32
-#  - range: [28, null]
-#    types:
-#      hardcoded::ExtrinsicAddress: MultiAddress<AccountId32,u32>
-#      <T::Lookup as StaticLookup>::Source: MultiAddress<AccountId32,u32>
-#      T::Keys: (AccountId, AccountId, AccountId, AccountId, AccountId, AccountId)
-#      ValidatorPrefs:
-#        commission: Compact<Perbill>
-#        blocked: bool
-#  - range: [28, 29]
-#    types:
-#      AccountInfo<Index, AccountData>:
-#        nonce: Index
-#        consumers: RefCount
-#        providers: RefCount
-#        data: AccountData
-#  - range: [30, null]
-#    types:
-#      AccountInfo<Index, AccountData>:
-#        nonce: Index
-#        consumers: RefCount
-#        providers: RefCount
-#        sufficients: RefCount
-#        data: AccountData
+      # XCM v0 Outcome used in older PolkadotXcm events
+      xcm::v0::Outcome: Outcome
+      Outcome:
+        _enum:
+          Complete: Weight
+          Incomplete: (Weight, XcmError)
+          Error: XcmError
+      # Minimal XCM error enum (v0). Order matches older runtimes sufficiently to decode common cases.
+      XcmError:
+        _enum:
+          Undefined: []
+          Unimplemented: []
+          UnhandledXcmMessage: []
+          UnhandledEffect: []
+          EscalationOfPrivilege: []
+          UntrustedReserveLocation: []
+          UntrustedTeleportLocation: []
+          DestinationNotInvertible: []
+          MultiLocationFull: []
+          MultiLocationNotInvertible: []
+          BadOrigin: []
+          InvalidLocation: []
+          AssetNotFound: []
+          FailedToTransactAsset: []
+          NotWithdrawable: []
+          LocationCannotHold: []
+          ExceedsMaxMessageSize: []
+          DestinationUnsupported: []
+          Locked: []
+          OrdersNotEmpty: []
+          DuplicateOrder: []
+          NotDepositable: []
+          Unwitnessed: []
+          UnknownClaim: []
+          Trap: u64
+          Overflow: []
+          UnimplementedXcmVersion: []
+          Incomplete: []
+          NetworkNotSupported: []
+          BadXcm: []
+          WeightLimitReached: []
+          WeightNotComputable: []
+          Barrier: []
+          SendFailed: []
+          Transport: []
+          Unroutable: []
+          UnknownError: []


### PR DESCRIPTION
validated historic decoding on Kusama Asset Hub storage and investigated missing types.

Ran block decoding storage against wss://asset-hub-kusama-rpc.n.dwellir.com:

Ran from 0 to 1400 blocks
Found spec version change at block 26668 (from spec version 1020 to 1021) - Ran from 26668 to  26730
Found spec version change at block 38244 (from spec version 1021 to 1022) - Ran from 38244 to 38264
Found spec version change at block 54248 (from spec version 1022 to 1023) - Ran from 54248 to 54289
Found spec version change at block 59658 (from spec version 1023 to 1024) - Ran from 59658 to 59690
Found spec version change at block 67650 (from spec version 1024 to 1025)  - Ran from 67650 to 67750
Found spec version change at block 82191 (from spec version 1025 to 1027) - Ran from 82191 to 82291
Found spec version change at block 83237 (from spec version 1027 to 1028)  - Ran from 83237 to 83250
Found spec version change at block 101503 (from spec version 1028 to 1029) - Ran from 101503 to 101520
Found spec version change at block 203466 (from spec version 1029 to 1030) - Ran from 203466 to 203480
Found spec version change at block 295787 (from spec version 1030 to 1031) - Ran from 295787 to 295800
Found spec version change at block 461692 (from spec version 1031 to 1032) - Ran from 461692 to 461710
Found spec version change at block 504329 (from spec version 1032 to 1033) - Ran from 504329 to 504340
Found spec version change at block 569326 (from spec version 1033 to 1038) - Ran from 569326 to 569340
Found spec version change at block 587686 (from spec version 1038 to 1039) - Ran from 587686 to 587700
Found spec version change at block 653183 (from spec version 1039 to 1040) - Ran from 653183 to 653200
Found spec version change at block 693487 (from spec version 1040 to 1042) - Ran from 693487 to 693500
Found spec version change at block 901442 (from spec version 1042 to 1045) - Ran from 901442 to 901455
Found spec version change at block 1375086 (from spec version 1045 to 1050) - Ran from 1375086 to 1375100

Command used
cargo run --release -- decode-blocks --types kusuma_ah_storage_types.yaml --url wss://asset-hub-kusama-rpc.n.dwellir.com --starting-block 0 --connections 50