### PR TITLE
Prep to release 0.14: snake case fields and Kusama RC block types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.14.0 (2025-11-19)
+
+- Add Kusama RC types capable of decoding historic blocks.
+- Enforce that type definitions have sane variable names and use **snake case** rather than **camel case** for field names. If field names were relied on, then note that some of them will change as a result of this.
+
 ## 0.13.0 (2025-11-14)
 
 - Separate the iterating over entries from the core `frame-decode` `*Info` traits; One only needs to implement `*Info` traits to work with `frame-decode`; the other traits are convenience traits.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "frame-decode"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "frame-metadata",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"


### PR DESCRIPTION
- Add Kusama RC types capable of decoding historic blocks (not yet storage entries).
- Enforce that type definitions have sane variable names and use **snake case** rather than **camel case** for field names. If field names were relied on, then note that some of them will change as a result of this.


\cc @TarikGul: If you rely on field names like `accountId`, note that using this version will lead to them changing to eg `account_id`. (This wRustification of field names will be good in the long run when we merge into Subxt and have codegen etc :))