### PR TITLE
Prep 0.15.0 release: AccountID32 is unnamed struct and from_bytes to decode legacy types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.15.0 (2025-11-20)
+
+- Update to `scale-info-legacy` 0.4.0.
+- Tweak `AccountId32` types to be unnamed structs rather than tuple types, so that they get a path.
+- Add `legacy_types::from_bytes` to convert provided bytes into a `ChainTypeRegistry`, negating the need to include `serde_yaml` or whatever in other crates.
+
 ## 0.14.0 (2025-11-19)
 
 - Add Kusama RC types capable of decoding historic blocks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "frame-decode"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "frame-metadata",
  "hex",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-legacy"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06423f0d7ea951547143aff4695c4c3e821e66c9b80729a3ff55fa93d23e93e6"
+checksum = "2500adfb429a0ffda37919df92c05d0c1359c10e0444c17253c84b84dfce542f"
 dependencies = [
  "hashbrown 0.15.0",
  "scale-type-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"
@@ -43,7 +43,7 @@ parity-scale-codec = { version = "3.6.12", default-features = false }
 scale-decode = { version = "0.16.0", default-features = false }
 scale-encode = { version = "0.10.0", default-features = false }
 scale-info = { version = "2.11.4", default-features = false }
-scale-info-legacy = { version = "0.3.2", default-features = false, optional = true }
+scale-info-legacy = { version = "0.4.0", default-features = false, optional = true }
 scale-type-resolver = "0.2.0"
 scale-value = { version = "0.18.0", default-features = false, optional = true }
 sp-crypto-hashing = { version = "0.1.0", default-features = false }
@@ -55,4 +55,4 @@ hex = "0.4.3"
 serde_yaml = "0.9"
 serde_json = "1"
 scale-value = "0.18.0"
-scale-info-legacy = "0.3.0"
+scale-info-legacy = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,15 @@ pub mod custom_values {
 pub mod legacy_types {
     //! This module contains legacy types that can be used to decode pre-V14 blocks and storage.
 
+    use alloc::boxed::Box;
+    type GenericError = Box<dyn core::error::Error + Send + Sync + 'static>;
+
+    /// Deserialize bytes into a [`scale_info_legacy::ChainTypeRegistry`].
+    pub fn from_bytes(bytes: &[u8]) -> Result<scale_info_legacy::ChainTypeRegistry, GenericError> {
+        let types = serde_yaml::from_slice(bytes)?;
+        Ok(types)
+    }
+
     pub mod polkadot {
         //! Legacy types for Polkadot chains.
 

--- a/src/utils/type_registry_from_metadata.rs
+++ b/src/utils/type_registry_from_metadata.rs
@@ -151,7 +151,7 @@ const _: () = {
                                 call_variants.push(Variant {
                                     index: c_idx as u8,
                                     name: call_name.to_owned(),
-                                    fields: VariantDesc::StructOf(args)
+                                    fields: VariantDesc::NamedStructOf(args)
                                 });
                             }
 
@@ -165,7 +165,7 @@ const _: () = {
                             call_module_variants.push(Variant {
                                 index: calls_index,
                                 name: module_name.to_owned(),
-                                fields: VariantDesc::TupleOf(vec![call_enum_lookup_name])
+                                fields: VariantDesc::UnnamedStructOf(vec![call_enum_lookup_name])
                             });
                         }
 
@@ -186,7 +186,7 @@ const _: () = {
                                 event_variants.push(Variant {
                                     index: e_idx as u8,
                                     name: event_name.to_owned(),
-                                    fields: VariantDesc::TupleOf(args)
+                                    fields: VariantDesc::UnnamedStructOf(args)
                                 });
                             }
 
@@ -200,7 +200,7 @@ const _: () = {
                             event_module_variants.push(Variant {
                                 index: events_index,
                                 name: module_name.to_owned(),
-                                fields: VariantDesc::TupleOf(vec![event_enum_lookup_name])
+                                fields: VariantDesc::UnnamedStructOf(vec![event_enum_lookup_name])
                             });
                         }
 
@@ -213,7 +213,7 @@ const _: () = {
                                 Variant {
                                     index: e_idx as u8,
                                     name: event_name.to_owned(),
-                                    fields: VariantDesc::TupleOf(Vec::new())
+                                    fields: VariantDesc::UnnamedStructOf(Vec::new())
                                 }
                             }).collect();
 
@@ -227,7 +227,7 @@ const _: () = {
                             error_module_variants.push(Variant {
                                 index: errors_index,
                                 name: module_name.to_owned(),
-                                fields: VariantDesc::TupleOf(vec![error_enum_lookup_name])
+                                fields: VariantDesc::UnnamedStructOf(vec![error_enum_lookup_name])
                             });
                         }
                     }

--- a/types/kusama_assethub_types.yaml
+++ b/types/kusama_assethub_types.yaml
@@ -1232,7 +1232,7 @@ global:
       approvals: Compact<u32>
 
     Index: u32
-    AccountId32: "[u8; 32]"
+    AccountId32: [ "[u8; 32]" ]
     AccountId: AccountId32
     SessionIndex: u32
     Bytes: Vec<u8>

--- a/types/kusama_relay_types.yaml
+++ b/types/kusama_relay_types.yaml
@@ -770,7 +770,7 @@ global:
     BalanceOf<T, I>: Balance
 
     Index: u32
-    AccountId32: "[u8; 32]"
+    AccountId32: [ "[u8; 32]" ]
     AccountId: AccountId32
     SessionIndex: u32
     Bytes: Vec<u8>

--- a/types/polkadot_relay_types.yaml
+++ b/types/polkadot_relay_types.yaml
@@ -762,7 +762,7 @@ global:
     BalanceOf<T, I>: Balance
 
     Index: u32
-    AccountId32: "[u8; 32]"
+    AccountId32: [ "[u8; 32]" ]
     AccountId: AccountId32
     SessionIndex: u32
     Bytes: Vec<u8>


### PR DESCRIPTION
- Update to `scale-info-legacy` 0.4.0.
- Tweak `AccountId32` types to be unnamed structs rather than tuple types, so that they get a path.
- Add `legacy_types::from_bytes` to convert provided bytes into a `ChainTypeRegistry`, negating the need to include `serde_yaml` or whatever in other crates.