### PR TITLE
Prep 0.16.1 release: expose ToTypeRegitry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.16.1 (2025-12-03)
+
+- Expose the `crate::helpers::ToTypeRegistry` trait so that inputs to `crate::helpers::type_registry_from_metadata` can be named. Make it sealed so that others cannot rely on it.
+
 ## 0.16.0 (2025-11-26)
 
 - Add a flag to `StorageInfo` which can be set in order to tell `frame-decode` to use the old version of V9 storage hashers when decoding storage keys. We need to manually toggle this flag when using metadata produced by runtimes prior to [this change](https://github.com/paritytech/substrate/commit/bbb363f4320b4a72e059c0fca96af42296d5a6bf#diff-aa7bc120d701816def0f2a5eb469212d2b7021d2fc9d3b284f843f3f8089e91a), which altered the storage hashers (and thus their encoding/decoding). Kusama prior to spec version 1032 is one such case when this needs to be toggled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "frame-decode"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "frame-metadata",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,9 @@ pub mod helpers {
         IntoEncodableValues, decode_with_error_tracing,
     };
     #[cfg(feature = "legacy")]
-    pub use crate::utils::{type_registry_from_metadata, type_registry_from_metadata_any};
+    pub use crate::utils::{
+        ToTypeRegistry, type_registry_from_metadata, type_registry_from_metadata_any,
+    };
 
     /// An alias to [`scale_decode::visitor::decode_with_visitor`]. This can be used to decode the byte ranges
     /// given back from functions like [`crate::extrinsics::decode_extrinsic`] or

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,12 +26,8 @@ pub use decode_with_error_tracing::{DecodeErrorTrace, decode_with_error_tracing}
 pub use either::Either;
 #[cfg(feature = "legacy")]
 pub use type_registry_from_metadata::{
-    type_registry_from_metadata, type_registry_from_metadata_any,
+    ToTypeRegistry, type_registry_from_metadata, type_registry_from_metadata_any,
 };
-
-// We don't want to expose these traits at the moment, but want to test them.
-#[cfg(all(test, feature = "legacy"))]
-pub use type_registry_from_metadata::ToTypeRegistry;
 
 /// A utility function to unwrap the `DecodeDifferent` enum found in earlier metadata versions.
 #[cfg(feature = "legacy")]

--- a/src/utils/type_registry_from_metadata.rs
+++ b/src/utils/type_registry_from_metadata.rs
@@ -60,10 +60,17 @@ pub fn type_registry_from_metadata_any(
 }
 
 #[cfg(feature = "legacy")]
-pub trait ToTypeRegistry {
+/// This is used with the [`type_registry_from_metadata`] helper function to extract types from the
+/// metadata. It is not intended to be implemented on anything else.
+pub trait ToTypeRegistry: sealed::Sealed {
+    /// Return a type registry.
     fn to_type_registry(
         &self,
     ) -> Result<scale_info_legacy::TypeRegistry, scale_info_legacy::lookup_name::ParseError>;
+}
+
+mod sealed {
+    pub trait Sealed {}
 }
 
 #[cfg(feature = "legacy")]
@@ -79,6 +86,7 @@ const _: () = {
 
     macro_rules! impl_for_v8_to_v13 {
         ($path:path $(, $builtin_index:ident)?) => {
+            impl sealed::Sealed for $path {}
             impl ToTypeRegistry for $path {
                 fn to_type_registry(&self) -> Result<scale_info_legacy::TypeRegistry, scale_info_legacy::lookup_name::ParseError> {
                     let metadata = self;


### PR DESCRIPTION
- Expose the `crate::helpers::ToTypeRegistry` trait so that inputs to `crate::helpers::type_registry_from_metadata` can be named. Make it sealed so that others cannot rely on it.