### PR TITLE
Prep v0.17.0 release: add methods for encoding extrinsics and related data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.17.0 (2025-12-03)
+
+- Add extrinsic encode methods in `frame_decode::extrinsics`. This covers encoding v4 and v5 unsigned and signed extrinsics, new traits for providing transaction extensions, encoding v4 and v5 signer payloads and encoding call data.
+
 ## 0.16.1 (2025-12-03)
 
 - Expose the `crate::helpers::ToTypeRegistry` trait so that inputs to `crate::helpers::type_registry_from_metadata` can be named. Make it sealed so that others cannot rely on it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "frame-metadata 23.0.1",
  "hex",
@@ -811,7 +811,7 @@ dependencies = [
 name = "frame-decode-tester"
 version = "0.1.0"
 dependencies = [
- "frame-decode 0.16.1",
+ "frame-decode 0.17.0",
  "frame-metadata 23.0.1",
  "hex",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,9 @@ pub mod extrinsics {
     pub use crate::methods::extrinsic_encoder::{
         ExtrinsicEncodeError, TransactionExtension, TransactionExtensionError,
         TransactionExtensions, TransactionExtensionsError,
-        best_v5_general_transaction_extension_version, encode_v4_signed, encode_v4_signed_to,
-        encode_v4_signed_with_info_to, encode_v4_signer_payload,
+        best_v5_general_transaction_extension_version, encode_call_data, encode_call_data_to,
+        encode_call_data_with_info, encode_call_data_with_info_to, encode_v4_signed,
+        encode_v4_signed_to, encode_v4_signed_with_info_to, encode_v4_signer_payload,
         encode_v4_signer_payload_with_info, encode_v4_unsigned, encode_v4_unsigned_to,
         encode_v4_unsigned_with_info_to, encode_v5_bare, encode_v5_bare_to,
         encode_v5_bare_with_info_to, encode_v5_general, encode_v5_general_to,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ pub mod extrinsics {
         encode_v5_signer_payload_with_info,
     };
     pub use crate::methods::extrinsic_type_info::{
-        ExtrinsicCallInfo, ExtrinsicExtensionInfo, ExtrinsicInfoArg, ExtrinsicInfoError,
-        ExtrinsicSignatureInfo, ExtrinsicTypeInfo,
+        ExtrinsicCallInfo, ExtrinsicCallInfoArg, ExtrinsicExtensionInfo, ExtrinsicExtensionInfoArg,
+        ExtrinsicInfoError, ExtrinsicSignatureInfo, ExtrinsicTypeInfo,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,19 @@ pub mod extrinsics {
         Extrinsic, ExtrinsicDecodeError, ExtrinsicExtensions, ExtrinsicOwned, ExtrinsicSignature,
         ExtrinsicType, NamedArg, decode_extrinsic,
     };
+    pub use crate::methods::extrinsic_encoder::{
+        TransactionExtension,
+        TransactionExtensionError,
+        TransactionExtensions,
+        TransactionExtensionsError,
+        ExtrinsicEncodeError,
+        encode_v4_signed, encode_v4_signed_to,
+        encode_v4_signed_with_info_to, encode_v4_signer_payload, encode_v4_signer_payload_with_info, 
+        encode_v4_unsigned, encode_v4_unsigned_to, encode_v4_unsigned_with_info_to, encode_v5_bare, 
+        encode_v5_bare_to, encode_v5_bare_with_info_to, encode_v5_general, encode_v5_general_to, 
+        encode_v5_general_with_info_to, encode_v5_signer_payload, encode_v5_signer_payload_with_info,
+        best_v5_general_transaction_extension_version,
+    };
     pub use crate::methods::extrinsic_type_info::{
         ExtrinsicCallInfo, ExtrinsicExtensionInfo, ExtrinsicInfoArg, ExtrinsicInfoError,
         ExtrinsicSignatureInfo, ExtrinsicTypeInfo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,17 +40,15 @@ pub mod extrinsics {
         ExtrinsicType, NamedArg, decode_extrinsic,
     };
     pub use crate::methods::extrinsic_encoder::{
-        TransactionExtension,
-        TransactionExtensionError,
-        TransactionExtensions,
-        TransactionExtensionsError,
-        ExtrinsicEncodeError,
-        encode_v4_signed, encode_v4_signed_to,
-        encode_v4_signed_with_info_to, encode_v4_signer_payload, encode_v4_signer_payload_with_info, 
-        encode_v4_unsigned, encode_v4_unsigned_to, encode_v4_unsigned_with_info_to, encode_v5_bare, 
-        encode_v5_bare_to, encode_v5_bare_with_info_to, encode_v5_general, encode_v5_general_to, 
-        encode_v5_general_with_info_to, encode_v5_signer_payload, encode_v5_signer_payload_with_info,
-        best_v5_general_transaction_extension_version,
+        ExtrinsicEncodeError, TransactionExtension, TransactionExtensionError,
+        TransactionExtensions, TransactionExtensionsError,
+        best_v5_general_transaction_extension_version, encode_v4_signed, encode_v4_signed_to,
+        encode_v4_signed_with_info_to, encode_v4_signer_payload,
+        encode_v4_signer_payload_with_info, encode_v4_unsigned, encode_v4_unsigned_to,
+        encode_v4_unsigned_with_info_to, encode_v5_bare, encode_v5_bare_to,
+        encode_v5_bare_with_info_to, encode_v5_general, encode_v5_general_to,
+        encode_v5_general_with_info_to, encode_v5_signer_payload,
+        encode_v5_signer_payload_with_info,
     };
     pub use crate::methods::extrinsic_type_info::{
         ExtrinsicCallInfo, ExtrinsicExtensionInfo, ExtrinsicInfoArg, ExtrinsicInfoError,

--- a/src/methods/extrinsic_decoder.rs
+++ b/src/methods/extrinsic_decoder.rs
@@ -619,7 +619,7 @@ where
     let call_index: u8 =
         Decode::decode(cursor).map_err(ExtrinsicDecodeError::CannotDecodeCallIndex)?;
     let call_info = info
-        .extrinsic_call_info(pallet_index, call_index)
+        .extrinsic_call_info_by_index(pallet_index, call_index)
         .map_err(|e| ExtrinsicDecodeError::CannotGetInfo(e.into_owned()))?;
 
     let mut call_data = vec![];

--- a/src/methods/extrinsic_encoder.rs
+++ b/src/methods/extrinsic_encoder.rs
@@ -897,7 +897,7 @@ where
     // Encode the "inner" bytes
     let mut encoded_inner = Vec::new();
 
-    // "is signed" + transaction protocol version (5)
+    // "is signed" (2 bits now) + transaction protocol version (5)
     (0b01000000 + 5u8).encode_to(&mut encoded_inner);
 
     // Version of the transaction extensions.

--- a/src/methods/extrinsic_encoder.rs
+++ b/src/methods/extrinsic_encoder.rs
@@ -1121,15 +1121,15 @@ pub fn encode_call_data_with_info_to<CallData, Resolver>(
     call_data: &CallData,
     call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
     type_resolver: &Resolver,
-    mut out: &mut Vec<u8>,
+    out: &mut Vec<u8>,
 ) -> Result<(), ExtrinsicEncodeError>
 where
     Resolver: TypeResolver,
     CallData: EncodeAsFields,
 {
     // Pallet and call index to identify the call:
-    call_info.pallet_index.encode_to(&mut out);
-    call_info.call_index.encode_to(&mut out);
+    call_info.pallet_index.encode_to(out);
+    call_info.call_index.encode_to(out);
 
     // Arguments to this call:
     let mut fields = call_info.args.iter().map(|arg| Field {

--- a/src/methods/extrinsic_encoder.rs
+++ b/src/methods/extrinsic_encoder.rs
@@ -384,12 +384,7 @@ where
     // Signed extensions (now Transaction Extensions)
     for (name, id) in iter_nonempty_extention_values(ext_info, type_resolver) {
         transaction_extensions
-            .encode_extension_value_to(
-                name,
-                id,
-                type_resolver,
-                &mut encoded_inner,
-            )
+            .encode_extension_value_to(name, id, type_resolver, &mut encoded_inner)
             .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
     }
 
@@ -500,24 +495,14 @@ where
     // Then the signer payload value (ie roughly the bytes that will appear in the tx)
     for (name, id) in iter_nonempty_extention_values(ext_info, type_resolver) {
         transaction_extensions
-            .encode_extension_value_for_signer_payload_to(
-                name,
-                id,
-                type_resolver,
-                &mut out,
-            )
+            .encode_extension_value_for_signer_payload_to(name, id, type_resolver, &mut out)
             .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
     }
 
     // Then the signer payload implicits (ie data we want to verify that is NOT in the tx)
     for (name, id) in iter_nonempty_extention_implicits(ext_info, type_resolver) {
         transaction_extensions
-            .encode_extension_implicit_to(
-                name,
-                id,
-                type_resolver,
-                &mut out,
-            )
+            .encode_extension_implicit_to(name, id, type_resolver, &mut out)
             .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
     }
 
@@ -728,14 +713,12 @@ where
             .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
 
         // Do we have all of the extension data for this version?
-        let have_data = ext_info
-            .extension_ids
-            .iter()
-            .all(|e| {
-                let is_value_empty = is_type_empty(e.id.clone(), type_resolver);
-                let is_implicit_empty = is_type_empty(e.implicit_id.clone(), type_resolver);
-                (is_value_empty && is_implicit_empty) || transaction_extensions.contains_extension(&e.name)
-            });
+        let have_data = ext_info.extension_ids.iter().all(|e| {
+            let is_value_empty = is_type_empty(e.id.clone(), type_resolver);
+            let is_implicit_empty = is_type_empty(e.implicit_id.clone(), type_resolver);
+            (is_value_empty && is_implicit_empty)
+                || transaction_extensions.contains_extension(&e.name)
+        });
 
         // If we have all of the data we need, encode the extrinsic,
         // else loop and try the next extension version.
@@ -923,12 +906,7 @@ where
     // Transaction Extensions next. These may include a signature/address
     for (name, id) in iter_nonempty_extention_values(ext_info, type_resolver) {
         transaction_extensions
-            .encode_extension_value_to(
-                name,
-                id,
-                type_resolver,
-                &mut encoded_inner,
-            )
+            .encode_extension_value_to(name, id, type_resolver, &mut encoded_inner)
             .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
     }
 
@@ -1049,24 +1027,14 @@ where
     // Then the signer payload value (ie roughly the bytes that will appear in the tx)
     for (name, id) in iter_nonempty_extention_values(ext_info, type_resolver) {
         transaction_extensions
-            .encode_extension_value_for_signer_payload_to(
-                name,
-                id,
-                type_resolver,
-                &mut out,
-            )
+            .encode_extension_value_for_signer_payload_to(name, id, type_resolver, &mut out)
             .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
     }
 
     // Then the signer payload implicits (ie data we want to verify that is NOT in the tx)
     for (name, id) in iter_nonempty_extention_implicits(ext_info, type_resolver) {
         transaction_extensions
-            .encode_extension_implicit_to(
-                name,
-                id,
-                type_resolver,
-                &mut out,
-            )
+            .encode_extension_implicit_to(name, id, type_resolver, &mut out)
             .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
     }
 
@@ -1212,10 +1180,11 @@ enum TransactionVersion {
 
 /// Iterate over the non-empty extension implicit name/IDs
 fn iter_nonempty_extention_implicits<'exts, 'info, Resolver: TypeResolver>(
-    extension_info: &'exts ExtrinsicExtensionInfo<'info, Resolver::TypeId>, 
-    types: &Resolver
+    extension_info: &'exts ExtrinsicExtensionInfo<'info, Resolver::TypeId>,
+    types: &Resolver,
 ) -> impl Iterator<Item = (&'exts str, Resolver::TypeId)> {
-    extension_info.extension_ids
+    extension_info
+        .extension_ids
         .iter()
         .filter(|arg| !is_type_empty(arg.implicit_id.clone(), types))
         .map(|arg| (&*arg.name, arg.implicit_id.clone()))
@@ -1223,10 +1192,11 @@ fn iter_nonempty_extention_implicits<'exts, 'info, Resolver: TypeResolver>(
 
 /// Iterate over the non-empty extension value name/IDs
 fn iter_nonempty_extention_values<'exts, 'info, Resolver: TypeResolver>(
-    extension_info: &'exts ExtrinsicExtensionInfo<'info, Resolver::TypeId>, 
-    types: &Resolver
+    extension_info: &'exts ExtrinsicExtensionInfo<'info, Resolver::TypeId>,
+    types: &Resolver,
 ) -> impl Iterator<Item = (&'exts str, Resolver::TypeId)> {
-    extension_info.extension_ids
+    extension_info
+        .extension_ids
         .iter()
         .filter(|arg| !is_type_empty(arg.id.clone(), types))
         .map(|arg| (&*arg.name, arg.id.clone()))

--- a/src/methods/extrinsic_encoder.rs
+++ b/src/methods/extrinsic_encoder.rs
@@ -1,0 +1,685 @@
+// Copyright (C) 2022-2026 Parity Technologies (UK) Ltd. (admin@parity.io)
+// This file is a part of the frame-decode crate.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod transaction_extensions;
+mod transaction_extension;
+
+use super::extrinsic_type_info::{ExtrinsicCallInfo, ExtrinsicExtensionInfo, ExtrinsicSignatureInfo, ExtrinsicTypeInfo, ExtrinsicInfoError};
+use scale_encode::{EncodeAsType, EncodeAsFields};
+use scale_type_resolver::{TypeResolver, Field};
+use parity_scale_codec::Encode;
+
+pub use transaction_extension::{
+    TransactionExtension,
+    TransactionExtensionError,
+};
+pub use transaction_extensions::{
+    TransactionExtensions,
+    TransactionExtensionsError,
+};
+
+/// An error returned trying to encode extrinsic call data.
+#[non_exhaustive]
+#[allow(missing_docs)]
+#[derive(Debug, thiserror::Error)]
+pub enum ExtrinsicEncodeError {
+    #[error("Cannot get extrinsic info: {0}")]
+    CannotGetInfo(ExtrinsicInfoError<'static>),
+    #[error("Extrinsic encoding failed: cannot encode call data: {0}")]
+    CannotEncodeCallData(scale_encode::Error),
+    #[error("Extrinsic encoding failed: cannot encode address: {0}")]
+    CannotEncodeAddress(scale_encode::Error),
+    #[error("Extrinsic encoding failed: cannot encode signature: {0}")]
+    CannotEncodeSignature(scale_encode::Error),
+    #[error("Extrinsic encoding failed: cannot encode transaction extensions: {0}")]
+    TransactionExtensions(TransactionExtensionsError),
+    #[error("Extrinsic encoding failed: cannot find a transaction extension version which enough data was given for.")]
+    CannotFindGoodExtensionVersion
+}
+
+/// This is used when it is possible to provide some type
+pub enum BytesOr<'a, T> {
+    Bytes(&'a [u8]),
+    Value(&'a T)
+}
+
+//// V4
+
+pub fn encode_v4_unsigned<CallData, Info, Resolver>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    info: &Info,
+    type_resolver: &Resolver,
+) -> Result<Vec<u8>, ExtrinsicEncodeError> 
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+{
+    let mut out = Vec::new();
+    encode_v4_unsigned_to(
+        pallet_name,
+        call_name,
+        call_data,
+        info,
+        type_resolver,
+        &mut out,
+    )?;
+    Ok(out)
+}
+
+pub fn encode_v4_unsigned_to<CallData, Info, Resolver>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    info: &Info,
+    type_resolver: &Resolver,
+    out: &mut Vec<u8>,
+) -> Result<(), ExtrinsicEncodeError> 
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+{
+    let call_info = info
+        .extrinsic_call_info_by_name(pallet_name, call_name)
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+    
+    encode_v4_unsigned_with_info_to(
+        call_data,
+        type_resolver,
+        &call_info,
+        out
+    )
+}
+
+pub fn encode_v4_unsigned_with_info_to<CallData, Resolver>(
+    call_data: &CallData,
+    type_resolver: &Resolver,
+    call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
+    out: &mut Vec<u8>,
+) -> Result<(), ExtrinsicEncodeError>
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver,
+{   
+    encode_unsigned_at_version_with_info_to(
+        call_data,
+        &call_info,
+        type_resolver,
+        TransactionVersion::V4,
+        out
+    )
+}
+
+pub fn encode_v4_signed<CallData, Info, Resolver, Exts, Address, Signature>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    transaction_extensions: &Exts,
+    address: &Address,
+    signature: &Signature,
+    info: &Info,
+    type_resolver: &Resolver,
+) -> Result<Vec<u8>, ExtrinsicEncodeError> 
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+    Exts: TransactionExtensions<Resolver>,
+    Address: EncodeAsType,
+    Signature: EncodeAsType,
+{
+    let mut out = Vec::new();
+    encode_v4_signed_to(
+        pallet_name,
+        call_name,
+        call_data,
+        transaction_extensions,
+        address,
+        signature,
+        info,
+        type_resolver,
+        &mut out,
+    )?;
+    Ok(out)
+}
+
+pub fn encode_v4_signed_to<CallData, Info, Resolver, Exts, Address, Signature>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    transaction_extensions: &Exts,
+    address: &Address,
+    signature: &Signature,
+    info: &Info,
+    type_resolver: &Resolver,
+    out: &mut Vec<u8>,
+) -> Result<(), ExtrinsicEncodeError>
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+    Exts: TransactionExtensions<Resolver>,
+    Address: EncodeAsType,
+    Signature: EncodeAsType,
+{
+    let call_info = info
+        .extrinsic_call_info_by_name(pallet_name, call_name)
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    let ext_info = info
+        .extrinsic_extension_info(None)
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    let sig_info = info
+        .extrinsic_signature_info()
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    encode_v4_signed_with_info_to(
+        call_data,
+        transaction_extensions,
+        address,
+        signature,
+        type_resolver,
+        &call_info,
+        &sig_info,
+        &ext_info,
+        out,
+    )
+}
+
+pub fn encode_v4_signed_with_info_to<CallData, Resolver, Exts, Address, Signature>(
+    call_data: &CallData,
+    transaction_extensions: &Exts,
+    address: &Address,
+    signature: &Signature,
+    type_resolver: &Resolver,
+    call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
+    sig_info: &ExtrinsicSignatureInfo<Resolver::TypeId>,
+    ext_info: &ExtrinsicExtensionInfo<Resolver::TypeId>,
+    out: &mut Vec<u8>,
+) -> Result<(), ExtrinsicEncodeError>
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver,
+    Exts: TransactionExtensions<Resolver>,
+    Address: EncodeAsType,
+    Signature: EncodeAsType,
+{
+    // Encode the "inner" bytes
+    let mut encoded_inner = Vec::new();
+    // "is signed" + transaction protocol version (4)
+    (0b10000000 + 4u8).encode_to(&mut encoded_inner);
+    // Who is this transaction from (corresponds to public key of signature)
+    address
+        .encode_as_type_to(sig_info.address_id.clone(), type_resolver, &mut encoded_inner)
+        .map_err(ExtrinsicEncodeError::CannotEncodeAddress)?;
+    // Signature for the above identity
+    signature
+        .encode_as_type_to(sig_info.signature_id.clone(), type_resolver, &mut encoded_inner)
+        .map_err(ExtrinsicEncodeError::CannotEncodeSignature)?;
+    // Signed extensions (now Transaction Extensions)
+    for ext in &ext_info.extension_ids {
+        transaction_extensions
+            .encode_extension_value_to(&ext.name, ext.id.clone(), type_resolver, &mut encoded_inner)
+            .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
+    }
+    // And now the actual call data, ie the arguments we're passing to the call
+    encode_call_data_with_info_to(
+        call_data,
+        call_info,
+        type_resolver,
+        &mut encoded_inner
+    ).map_err(ExtrinsicEncodeError::CannotEncodeCallData)?;
+
+    // Now, encoding these inner bytes prefixes the compact length to the beginning:
+    encoded_inner.encode_to(out);
+    Ok(())
+}
+
+pub fn encode_v4_signer_payload<CallData, Info, Resolver, Exts>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    transaction_extensions: &Exts,
+    info: &Info,
+    type_resolver: &Resolver,
+) -> Result<Vec<u8>, ExtrinsicEncodeError> 
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+    Exts: TransactionExtensions<Resolver>,
+    Info::TypeId: Clone,
+{
+    let call_info = info
+        .extrinsic_call_info_by_name(pallet_name, call_name)
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    let ext_info = info
+        .extrinsic_extension_info(None)
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    encode_v4_signer_payload_with_info(
+        call_data,
+        transaction_extensions,
+        type_resolver,
+        &call_info,
+        &ext_info,
+    )    
+}
+
+pub fn encode_v4_signer_payload_with_info<CallData, Resolver, Exts>(
+    call_data: &CallData,
+    transaction_extensions: &Exts,
+    type_resolver: &Resolver,
+    call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
+    ext_info: &ExtrinsicExtensionInfo<Resolver::TypeId>,
+) -> Result<Vec<u8>, ExtrinsicEncodeError> 
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver,
+    Exts: TransactionExtensions<Resolver>,
+{
+    let mut out = Vec::new();
+
+    // First encode call data
+    encode_call_data_with_info_to(
+        call_data,
+        &call_info,
+        type_resolver,
+        &mut out
+    ).map_err(ExtrinsicEncodeError::CannotEncodeCallData)?;
+    // Then the signer payload value (ie roughly the bytes that will appear in the tx)
+    for ext in &ext_info.extension_ids {
+        transaction_extensions
+            .encode_extension_value_for_signer_payload_to(&ext.name, ext.id.clone(), type_resolver, &mut out)
+            .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
+    }
+    // Then the signer payload implicits (ie data we want to verify that is NOT in the tx)
+    for ext in &ext_info.extension_ids {
+        transaction_extensions
+            .encode_extension_implicit_to(&ext.name, ext.id.clone(), type_resolver, &mut out)
+            .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
+    }
+    // Finally we need to hash it if it's too long
+    if out.len() > 256 {
+        out = sp_crypto_hashing::blake2_256(&out).to_vec();
+    }
+
+    Ok(out)
+}
+
+//// V5
+
+pub fn encode_v5_bare<CallData, Info, Resolver>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    info: &Info,
+    type_resolver: &Resolver,
+) -> Result<Vec<u8>, ExtrinsicEncodeError> 
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+{
+    let mut out = Vec::new();
+    encode_v5_bare_to(
+        pallet_name,
+        call_name,
+        call_data,
+        info,
+        type_resolver,
+        &mut out,
+    )?;
+    Ok(out)
+}
+
+pub fn encode_v5_bare_to<CallData, Info, Resolver>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    info: &Info,
+    type_resolver: &Resolver,
+    out: &mut Vec<u8>,
+) -> Result<(), ExtrinsicEncodeError> 
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+{
+    let call_info = info
+        .extrinsic_call_info_by_name(pallet_name, call_name)
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+    
+    encode_v5_bare_with_info_to(
+        call_data,
+        type_resolver,
+        &call_info,
+        out
+    )
+}
+
+pub fn encode_v5_bare_with_info_to<CallData, Resolver>(
+    call_data: &CallData,
+    type_resolver: &Resolver,
+    call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
+    out: &mut Vec<u8>,
+) -> Result<(), ExtrinsicEncodeError>
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver,
+{   
+    encode_unsigned_at_version_with_info_to(
+        call_data,
+        &call_info,
+        type_resolver,
+        TransactionVersion::V5,
+        out
+    )
+}
+
+pub fn best_v5_general_transaction_extension_version<Exts, Info, Resolver>(
+    transaction_extensions: &Exts,
+    info: &Info,
+) -> Result<u8, ExtrinsicEncodeError>
+where
+    Info: ExtrinsicTypeInfo,
+    Exts: TransactionExtensions<Resolver>,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+{
+    let extension_versions = info
+        .extrinsic_extension_version_info()
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    for ext_version in extension_versions {
+        // get extension info for each version.
+        let ext_info = info
+            .extrinsic_extension_info(Some(ext_version))
+            .map_err(|i| i.into_owned())
+            .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+        // Do we have all of the extension data for this version?
+        let have_data = ext_info.extension_ids.iter().all(|e| {
+            transaction_extensions.contains_extension(&e.name)
+        });
+
+        // If we have all of the data we need, encode the extrinsic,
+        // else loop and try the next extension version.
+        if have_data {
+            return Ok(ext_version)
+        }
+    }
+
+    Err(ExtrinsicEncodeError::CannotFindGoodExtensionVersion)
+}
+
+pub fn encode_v5_general<CallData, Info, Resolver, Exts>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    transaction_extension_version: u8,
+    transaction_extensions: &Exts,
+    info: &Info,
+    type_resolver: &Resolver,
+) -> Result<Vec<u8>, ExtrinsicEncodeError>
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+    Exts: TransactionExtensions<Resolver>,
+{
+    let mut out = Vec::new();
+    encode_v5_general_to(
+        pallet_name,
+        call_name,
+        call_data,
+        transaction_extension_version,
+        transaction_extensions,
+        info,
+        type_resolver,
+        &mut out,
+    )?;
+    Ok(out)
+}
+
+pub fn encode_v5_general_to<CallData, Info, Resolver, Exts>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    transaction_extension_version: u8,
+    transaction_extensions: &Exts,
+    info: &Info,
+    type_resolver: &Resolver,
+    out: &mut Vec<u8>,
+) -> Result<(), ExtrinsicEncodeError>
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+    Exts: TransactionExtensions<Resolver>,
+{
+    let call_info = info
+        .extrinsic_call_info_by_name(pallet_name, call_name)
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    let ext_info = info
+        .extrinsic_extension_info(Some(transaction_extension_version))
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    return encode_v5_general_with_info_to(
+        call_data,
+        transaction_extension_version,
+        transaction_extensions,
+        type_resolver,
+        &call_info,
+        &ext_info,
+        out,
+    )
+}
+
+pub fn encode_v5_general_with_info_to<CallData, Resolver, Exts>(
+    call_data: &CallData,
+    transaction_extension_version: u8,
+    transaction_extensions: &Exts,
+    type_resolver: &Resolver,
+    call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
+    ext_info: &ExtrinsicExtensionInfo<Resolver::TypeId>,
+    out: &mut Vec<u8>,
+) -> Result<(), ExtrinsicEncodeError>
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver,
+    Exts: TransactionExtensions<Resolver>,
+{
+    // Encode the "inner" bytes
+    let mut encoded_inner = Vec::new();
+    // "is signed" + transaction protocol version (4)
+    (0b01000000 + 5u8).encode_to(&mut encoded_inner);
+    // Version of the transaction extensions.
+    transaction_extension_version.encode_to(&mut encoded_inner);
+    // Transaction Extensions next. These may include a signature/address.
+    for ext in &ext_info.extension_ids {
+        transaction_extensions
+            .encode_extension_value_to(&ext.name, ext.id.clone(), type_resolver, &mut encoded_inner)
+            .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
+    }
+    // And now the actual call data, ie the arguments we're passing to the call
+    encode_call_data_with_info_to(
+        call_data,
+        call_info,
+        type_resolver,
+        &mut encoded_inner
+    ).map_err(ExtrinsicEncodeError::CannotEncodeCallData)?;
+
+    // Now, encoding these inner bytes prefixes the compact length to the beginning:
+    encoded_inner.encode_to(out);
+    Ok(())
+}
+
+pub fn encode_v5_signer_payload<CallData, Info, Resolver, Exts>(
+    pallet_name: &str,
+    call_name: &str,
+    call_data: &CallData,
+    transaction_extension_version: u8,
+    transaction_extensions: &Exts,
+    info: &Info,
+    type_resolver: &Resolver,
+) -> Result<[u8; 32], ExtrinsicEncodeError> 
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver<TypeId = Info::TypeId>,
+    Info: ExtrinsicTypeInfo,
+    Exts: TransactionExtensions<Resolver>,
+    Info::TypeId: Clone,
+{
+    let call_info = info
+        .extrinsic_call_info_by_name(pallet_name, call_name)
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    let ext_info = info
+        .extrinsic_extension_info(Some(transaction_extension_version))
+        .map_err(|i| i.into_owned())
+        .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
+
+    encode_v5_signer_payload_with_info(
+        call_data,
+        transaction_extensions,
+        type_resolver,
+        &call_info,
+        &ext_info,
+    )    
+}
+
+pub fn encode_v5_signer_payload_with_info<CallData, Resolver, Exts>(
+    call_data: &CallData,
+    transaction_extensions: &Exts,
+    type_resolver: &Resolver,
+    call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
+    ext_info: &ExtrinsicExtensionInfo<Resolver::TypeId>,
+) -> Result<[u8; 32], ExtrinsicEncodeError> 
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver,
+    Exts: TransactionExtensions<Resolver>,
+{
+    let mut out = Vec::new();
+
+    // First encode call data
+    encode_call_data_with_info_to(
+        call_data,
+        &call_info,
+        type_resolver,
+        &mut out
+    ).map_err(ExtrinsicEncodeError::CannotEncodeCallData)?;
+
+    // Then the signer payload value (ie roughly the bytes that will appear in the tx)
+    for ext in &ext_info.extension_ids {
+        transaction_extensions
+            .encode_extension_value_for_signer_payload_to(&ext.name, ext.id.clone(), type_resolver, &mut out)
+            .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
+    }
+
+    // Then the signer payload implicits (ie data we want to verify that is NOT in the tx)
+    for ext in &ext_info.extension_ids {
+        transaction_extensions
+            .encode_extension_implicit_to(&ext.name, ext.id.clone(), type_resolver, &mut out)
+            .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
+    }
+
+    // Finally hash it (regardless of length).
+    Ok(sp_crypto_hashing::blake2_256(&out))
+}
+
+// V4 unsigned and V5 bare extrinsics are basically encoded 
+// in the same way; this helper can do either.
+fn encode_unsigned_at_version_with_info_to<CallData, Resolver>(
+    call_data: &CallData,
+    call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
+    type_resolver: &Resolver,
+    tx_version: TransactionVersion,
+    out: &mut Vec<u8>,
+) -> Result<(), ExtrinsicEncodeError> 
+where
+    Resolver: TypeResolver,
+    CallData: EncodeAsFields,
+{
+    // Build our inner, non-length-prefixed extrinsic:
+    let inner = {
+        let mut out = Vec::new();
+        // Transaction version (4):
+        (tx_version as u8).encode_to(&mut out);
+        // Pallet and call index to identify the call:
+        call_info.pallet_index.encode_to(&mut out);
+        call_info.call_index.encode_to(&mut out);
+        // Then the arguments for the call:
+        encode_call_data_with_info_to(
+            call_data,
+            call_info,
+            type_resolver,
+            &mut out
+        ).map_err(ExtrinsicEncodeError::CannotEncodeCallData)?;
+        out
+    };
+    
+    // Encode the inner vec to prefix the compact length to it:
+    inner.encode_to(out);
+    Ok(())
+}
+
+#[derive(Copy, Clone)]
+#[repr(u8)]
+enum TransactionVersion {
+    V4 = 4u8,
+    V5 = 5u8,
+}
+
+// Encoding call data is the same for any extrinsic; this method does this part.
+fn encode_call_data_with_info_to<Resolver, CallData>(
+    call_data: &CallData, 
+    call_info: &ExtrinsicCallInfo<Resolver::TypeId>, 
+    type_resolver: &Resolver,
+    out: &mut Vec<u8>,
+) -> Result<(), scale_encode::Error> 
+where
+    Resolver: TypeResolver,
+    CallData: EncodeAsFields,
+{
+    let mut fields = call_info.args.iter().map(|arg| {
+        Field {
+            name: Some(&*arg.name),
+            id: arg.id.clone()
+        }
+    });
+
+    call_data
+        .encode_as_fields_to(&mut fields, type_resolver, out)?;
+
+    Ok(())
+}

--- a/src/methods/extrinsic_encoder.rs
+++ b/src/methods/extrinsic_encoder.rs
@@ -49,8 +49,6 @@ pub enum ExtrinsicEncodeError {
     CannotFindGoodExtensionVersion,
 }
 
-//// V4
-
 /// Encode a V4 unsigned extrinsic (also known as an inherent).
 ///
 /// This is the same as [`encode_v4_unsigned_to`], but returns the encoded extrinsic as a `Vec<u8>`,
@@ -173,7 +171,7 @@ where
 {
     encode_unsigned_at_version_with_info_to(
         call_data,
-        &call_info,
+        call_info,
         type_resolver,
         TransactionVersion::V4,
         out,
@@ -217,6 +215,7 @@ where
 ///     &metadata.types,
 /// ).unwrap();
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn encode_v4_signed<CallData, Info, Resolver, Exts, Address, Signature>(
     pallet_name: &str,
     call_name: &str,
@@ -287,6 +286,7 @@ where
 ///     &mut encoded,
 /// ).unwrap();
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn encode_v4_signed_to<CallData, Info, Resolver, Exts, Address, Signature>(
     pallet_name: &str,
     call_name: &str,
@@ -339,6 +339,7 @@ where
 /// Unlike [`encode_v4_signed_to`], which obtains the call, signature, and extension info internally
 /// given the pallet and call names, this function takes these as arguments. This is useful if you
 /// already have this information available, for example if you are encoding multiple extrinsics.
+#[allow(clippy::too_many_arguments)]
 pub fn encode_v4_signed_with_info_to<CallData, Resolver, Exts, Address, Signature>(
     call_data: &CallData,
     transaction_extensions: &Exts,
@@ -485,7 +486,7 @@ where
     let mut out = Vec::new();
 
     // First encode call data
-    encode_call_data_with_info_to(call_data, &call_info, type_resolver, &mut out)?;
+    encode_call_data_with_info_to(call_data, call_info, type_resolver, &mut out)?;
     // Then the signer payload value (ie roughly the bytes that will appear in the tx)
     for ext in &ext_info.extension_ids {
         transaction_extensions
@@ -510,8 +511,6 @@ where
 
     Ok(out)
 }
-
-//// V5
 
 /// Encode a V5 bare extrinsic (also known as an inherent), ready to submit.
 ///
@@ -638,7 +637,7 @@ where
 {
     encode_unsigned_at_version_with_info_to(
         call_data,
-        &call_info,
+        call_info,
         type_resolver,
         TransactionVersion::V5,
         out,
@@ -832,6 +831,7 @@ where
 ///     &mut encoded,
 /// ).unwrap();
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn encode_v5_general_to<CallData, Info, Resolver, Exts>(
     pallet_name: &str,
     call_name: &str,
@@ -858,7 +858,7 @@ where
         .map_err(|i| i.into_owned())
         .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
 
-    return encode_v5_general_with_info_to(
+    encode_v5_general_with_info_to(
         call_data,
         transaction_extension_version,
         transaction_extensions,
@@ -866,7 +866,7 @@ where
         &call_info,
         &ext_info,
         out,
-    );
+    )
 }
 
 /// Encode a V5 general extrinsic to a provided output buffer, using pre-computed type information.
@@ -1012,7 +1012,7 @@ where
     let mut out = Vec::new();
 
     // First encode call data
-    encode_call_data_with_info_to(call_data, &call_info, type_resolver, &mut out)?;
+    encode_call_data_with_info_to(call_data, call_info, type_resolver, &mut out)?;
 
     // Then the signer payload value (ie roughly the bytes that will appear in the tx)
     for ext in &ext_info.extension_ids {

--- a/src/methods/extrinsic_encoder/transaction_extension.rs
+++ b/src/methods/extrinsic_encoder/transaction_extension.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use scale_type_resolver::TypeResolver;
 
 /// This can be implemented for anything which is a valid Substrate transaction extension.
@@ -26,16 +28,16 @@ pub trait TransactionExtension<Resolver: TypeResolver> {
     /// this should encode the value (ie the bytes that will appear in the
     /// transaction) to the provided `Vec`, or encode nothing and emit an error.
     fn encode_value_to(
-        &self, 
-        type_id: Resolver::TypeId, 
-        type_resolver: &Resolver, 
-        out: &mut Vec<u8>
+        &self,
+        type_id: Resolver::TypeId,
+        type_resolver: &Resolver,
+        out: &mut Vec<u8>,
     ) -> Result<(), TransactionExtensionError>;
 
     /// Given type information for the expected transaction extension,
     /// this should encode the value that will be signed as a part of the
     /// signer payload.
-    /// 
+    ///
     /// This defaults to calling [`Self::encode_value_to`] if not implemented.
     /// In most cases this is fine, but for V5 extrinsics we can optionally provide
     /// the signature inside a transaction extension, and so that transaction would be
@@ -43,9 +45,9 @@ pub trait TransactionExtension<Resolver: TypeResolver> {
     /// method to encode nothing.
     fn encode_value_for_signer_payload_to(
         &self,
-        type_id: Resolver::TypeId, 
-        type_resolver: &Resolver, 
-        out: &mut Vec<u8>
+        type_id: Resolver::TypeId,
+        type_resolver: &Resolver,
+        out: &mut Vec<u8>,
     ) -> Result<(), TransactionExtensionError> {
         self.encode_value_to(type_id, type_resolver, out)
     }
@@ -54,10 +56,10 @@ pub trait TransactionExtension<Resolver: TypeResolver> {
     /// this should encode the implicit (ie the bytes that will appear in the
     /// signer payload) to the provided `Vec`, or encode nothing and emit an error.
     fn encode_implicit_to(
-        &self, 
-        type_id: Resolver::TypeId, 
-        type_resolver: &Resolver, 
-        out: &mut Vec<u8>
+        &self,
+        type_id: Resolver::TypeId,
+        type_resolver: &Resolver,
+        out: &mut Vec<u8>,
     ) -> Result<(), TransactionExtensionError>;
 }
 

--- a/src/methods/extrinsic_encoder/transaction_extension.rs
+++ b/src/methods/extrinsic_encoder/transaction_extension.rs
@@ -22,7 +22,7 @@ use scale_type_resolver::TypeResolver;
 /// explicit `value` bytes to a transaction, or "implicit" bytes to a transaction signer payload.
 pub trait TransactionExtension<Resolver: TypeResolver> {
     /// The name of this transaction extension.
-    fn extension_name(&self) -> &'static str;
+    const NAME: &str;
 
     /// Given type information for the expected transaction extension,
     /// this should encode the value (ie the bytes that will appear in the

--- a/src/methods/extrinsic_encoder/transaction_extension.rs
+++ b/src/methods/extrinsic_encoder/transaction_extension.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2022-2026 Parity Technologies (UK) Ltd. (admin@parity.io)
+// This file is a part of the frame-decode crate.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use scale_type_resolver::TypeResolver;
+
+/// This can be implemented for anything which is a valid Substrate transaction extension.
+/// Transaction extensions each have a unique name to identify them, and are able to encode
+/// explicit `value` bytes to a transaction, or "implicit" bytes to a transaction signer payload.
+pub trait TransactionExtension<Resolver: TypeResolver> {
+    /// The name of this transaction extension.
+    fn extension_name(&self) -> &'static str;
+
+    /// Given type information for the expected transaction extension,
+    /// this should encode the value (ie the bytes that will appear in the
+    /// transaction) to the provided `Vec`, or encode nothing and emit an error.
+    fn encode_value_to(
+        &self, 
+        type_id: Resolver::TypeId, 
+        type_resolver: &Resolver, 
+        out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionError>;
+
+    /// Given type information for the expected transaction extension,
+    /// this should encode the value that will be signed as a part of the
+    /// signer payload.
+    /// 
+    /// This defaults to calling [`Self::encode_value_to`] if not implemented.
+    /// In most cases this is fine, but for V5 extrinsics we can optionally provide
+    /// the signature inside a transaction extension, and so that transaction would be
+    /// unable to encode anything for the signer payload and thus should override this
+    /// method to encode nothing.
+    fn encode_value_for_signer_payload_to(
+        &self,
+        type_id: Resolver::TypeId, 
+        type_resolver: &Resolver, 
+        out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionError> {
+        self.encode_value_to(type_id, type_resolver, out)
+    }
+
+    /// Given type information for the expected transaction extension,
+    /// this should encode the implicit (ie the bytes that will appear in the
+    /// signer payload) to the provided `Vec`, or encode nothing and emit an error.
+    fn encode_implicit_to(
+        &self, 
+        type_id: Resolver::TypeId, 
+        type_resolver: &Resolver, 
+        out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionError>;
+}
+
+/// This error will be returned if any of the methods in [`TransactionExtension`] fail.
+pub type TransactionExtensionError = Box<dyn core::error::Error + Send + Sync + 'static>;

--- a/src/methods/extrinsic_encoder/transaction_extensions.rs
+++ b/src/methods/extrinsic_encoder/transaction_extensions.rs
@@ -1,0 +1,335 @@
+// Copyright (C) 2022-2026 Parity Technologies (UK) Ltd. (admin@parity.io)
+// This file is a part of the frame-decode crate.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use scale_type_resolver::TypeResolver;
+use super::transaction_extension::{ TransactionExtension, TransactionExtensionError };
+
+/// This trait can be implemented for anything which represents a set of transaction extensions.
+/// It's implemented by default for tuples of items which implement [`TransactionExtension`],
+/// and for slices of `&dyn TransactionExtension`.
+pub trait TransactionExtensions<Resolver: TypeResolver> {
+    /// Is a given transaction extension contained within this set?
+    fn contains_extension(&self, name: &str) -> bool; 
+
+    /// This will be called given the name of each transaction extension we
+    /// wish to obtain the encoded bytes to. Implementations are expected to
+    /// write the bytes that should be included in the **transaction** to the given [`Vec`],
+    /// or return an error if no such bytes can be written.
+    fn encode_extension_value_to(
+        &self,
+        name: &str, 
+        type_id: Resolver::TypeId, 
+        type_resolver: &Resolver, 
+        out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionsError>;
+
+    /// This will be called given the name of each transaction extension we
+    /// wish to obtain the encoded bytes to. Implementations are expected to
+    /// write the bytes that should be included in the **signer payload value 
+    /// section** to the given [`Vec`], or return an error if no such bytes can be 
+    /// written.
+    /// 
+    /// This defaults to calling [`Self::encode_extension_value_to`] if not implemented.
+    /// In most cases this is fine, but for V5 extrinsics we can optionally provide
+    /// the signature inside a transaction extension, and so that transaction would be
+    /// unable to encode anything for the signer payload.
+    fn encode_extension_value_for_signer_payload_to(
+        &self,
+        name: &str, 
+        type_id: Resolver::TypeId, 
+        type_resolver: &Resolver, 
+        out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionsError> {
+        self.encode_extension_value_to(name, type_id, type_resolver, out)
+    }
+
+    /// This will be called given the name of each transaction extension we
+    /// wish to obtain the encoded bytes to. Implementations are expected to
+    /// write the bytes that should be included in the **signer payload implicit** 
+    /// to the given [`Vec`], or return an error if no such bytes can be written.
+    fn encode_extension_implicit_to(
+        &self,
+        name: &str, 
+        type_id: Resolver::TypeId, 
+        type_resolver: &Resolver, 
+        out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionsError>;
+}
+
+/// This error will be returned if any of the methods in [`TransactionExtensions`] fail.
+#[derive(Debug, thiserror::Error)]
+pub enum TransactionExtensionsError {
+    #[error("Cannot encode transaction extension '{0}': This extension could not be found")]
+    NotFound(String),
+    #[error("Cannot encode transaction extension '{extension_name}': {error}")]
+    Other {
+        extension_name: String,
+        error: TransactionExtensionError,
+    }
+}
+
+// `TransactionExtension` is object safe and so `TransactionExtensions` can be implemented
+// for slices of `&dyn TransactionExtension`s.
+impl <Resolver: TypeResolver> TransactionExtensions<Resolver> for [&dyn TransactionExtension<Resolver>] {
+    fn contains_extension(&self, name: &str) -> bool {
+        self.iter().find(|e| e.extension_name() == name).is_some()
+    }
+
+    fn encode_extension_value_to(
+        &self,
+        name: &str, 
+        type_id: <Resolver as TypeResolver>::TypeId, 
+        type_resolver: &Resolver, 
+        out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionsError> {
+        let len = out.len();
+        for ext in self {
+            if ext.extension_name() == name {
+                return ext.encode_value_to(type_id, type_resolver, out)
+                    .map_err(|e| {
+                        // Protection: if we are returning an error then
+                        // no bytes should have been encoded to the given
+                        // Vec. Ensure that this is true:
+                        while out.len() > len {
+                            out.pop();
+                        }
+                        TransactionExtensionsError::Other {
+                            extension_name: name.to_owned(),
+                            error: e,
+                        }
+                    });
+            }
+        }
+        Err(TransactionExtensionsError::NotFound(name.to_owned()))
+    }
+
+    fn encode_extension_value_for_signer_payload_to(
+        &self,
+        name: &str, 
+        type_id: <Resolver as TypeResolver>::TypeId, 
+        type_resolver: &Resolver, 
+        out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionsError> {
+        let len = out.len();
+        for ext in self {
+            if ext.extension_name() == name {
+                return ext.encode_value_for_signer_payload_to(type_id, type_resolver, out)
+                    .map_err(|e| {
+                        // Protection: if we are returning an error then
+                        // no bytes should have been encoded to the given
+                        // Vec. Ensure that this is true:
+                        while out.len() > len {
+                            out.pop();
+                        }
+                        TransactionExtensionsError::Other {
+                            extension_name: name.to_owned(),
+                            error: e,
+                        }
+                    });
+            }
+        }
+        Err(TransactionExtensionsError::NotFound(name.to_owned()))
+    }
+    
+    fn encode_extension_implicit_to(
+        &self,
+        name: &str, 
+        type_id: <Resolver as TypeResolver>::TypeId, 
+        type_resolver: &Resolver, 
+        out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionsError> {
+        let len = out.len();
+        for ext in self {
+            if ext.extension_name() == name {
+                return ext.encode_implicit_to(type_id, type_resolver, out)
+                    .map_err(|e| {
+                        // Protection: if we are returning an error then
+                        // no bytes should have been encoded to the given
+                        // Vec. Ensure that this is true:
+                        while out.len() > len {
+                            out.pop();
+                        }
+                        TransactionExtensionsError::Other {
+                            extension_name: name.to_owned(),
+                            error: e,
+                        }
+                    });
+            }
+        }
+        Err(TransactionExtensionsError::NotFound(name.to_owned()))
+    }
+}
+
+// Empty tuples impl `TransactionExtensions`: if called they emit a not found error.
+impl <Resolver: TypeResolver> TransactionExtensions<Resolver> for () {
+    fn contains_extension(&self, _name: &str) -> bool {
+        false
+    }
+
+    fn encode_extension_value_to(
+        &self,
+        name: &str, 
+        _type_id: <Resolver as TypeResolver>::TypeId, 
+        _type_resolver: &Resolver, 
+        _out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionsError> {
+        Err(TransactionExtensionsError::NotFound(name.to_owned()))
+    }
+
+    fn encode_extension_implicit_to(
+        &self,
+        name: &str, 
+        _type_id: <Resolver as TypeResolver>::TypeId, 
+        _type_resolver: &Resolver, 
+        _out: &mut Vec<u8>
+    ) -> Result<(), TransactionExtensionsError> {
+        Err(TransactionExtensionsError::NotFound(name.to_owned()))
+    }
+}
+
+// Non-empty tuples impl `TransactionExtensions`: for each extension we do a linear
+// search through the tuple items to find it and call the appropriate encode method.
+macro_rules! impl_tuples {
+    ($($ident:ident $index:tt),*) => {
+        impl <Resolver: TypeResolver $(,$ident)*> TransactionExtensions<Resolver> for ($($ident,)*) 
+        where
+            $($ident: TransactionExtension<Resolver>,)*
+        {
+            fn contains_extension(&self, name: &str) -> bool {
+                $(
+                    if self.$index.extension_name() == name {
+                        return true
+                    }
+                )*
+                false         
+            }
+
+            fn encode_extension_value_to(
+                &self, 
+                name: &str, 
+                type_id: <Resolver as TypeResolver>::TypeId, 
+                type_resolver: &Resolver, 
+                out: &mut Vec<u8>
+            ) -> Result<(), TransactionExtensionsError> {
+                let len = out.len();
+
+                $(
+                    if self.$index.extension_name() == name {
+                        return self.$index.encode_value_to(type_id, type_resolver, out)
+                            .map_err(|e| {
+                                // Protection: if we are returning an error then
+                                // no bytes should have been encoded to the given
+                                // Vec. Ensure that this is true:
+                                while out.len() > len {
+                                    out.pop();
+                                }
+                                TransactionExtensionsError::Other {
+                                    extension_name: name.to_owned(),
+                                    error: e,
+                                }
+                            });
+                    }
+                )*
+
+                Err(TransactionExtensionsError::NotFound(name.to_owned()))
+            }
+
+            fn encode_extension_value_for_signer_payload_to(
+                &self, 
+                name: &str, 
+                type_id: <Resolver as TypeResolver>::TypeId, 
+                type_resolver: &Resolver, 
+                out: &mut Vec<u8>
+            ) -> Result<(), TransactionExtensionsError> {
+                let len = out.len();
+
+                $(
+                    if self.$index.extension_name() == name {
+                        return self.$index.encode_value_for_signer_payload_to(type_id, type_resolver, out)
+                            .map_err(|e| {
+                                // Protection: if we are returning an error then
+                                // no bytes should have been encoded to the given
+                                // Vec. Ensure that this is true:
+                                while out.len() > len {
+                                    out.pop();
+                                }
+                                TransactionExtensionsError::Other {
+                                    extension_name: name.to_owned(),
+                                    error: e,
+                                }
+                            });
+                    }
+                )*
+
+                Err(TransactionExtensionsError::NotFound(name.to_owned()))
+            }
+
+            fn encode_extension_implicit_to(
+                &self, 
+                name: &str, 
+                type_id: <Resolver as TypeResolver>::TypeId, 
+                type_resolver: &Resolver, 
+                out: &mut Vec<u8>
+            ) -> Result<(), TransactionExtensionsError> {
+                let len = out.len();
+
+                $(
+                    if self.$index.extension_name() == name {
+                        return self.$index.encode_implicit_to(type_id, type_resolver, out)
+                            .map_err(|e| {
+                                // Protection: if we are returning an error then
+                                // no bytes should have been encoded to the given
+                                // Vec. Ensure that this is true:
+                                while out.len() > len {
+                                    out.pop();
+                                }
+                                TransactionExtensionsError::Other {
+                                    extension_name: name.to_owned(),
+                                    error: e,
+                                }
+                            });
+                    }
+                )*
+
+                Err(TransactionExtensionsError::NotFound(name.to_owned()))
+            }
+        }
+    }
+}
+
+#[rustfmt::skip]
+const _: () = {
+    impl_tuples!(A 0);
+    impl_tuples!(A 0, B 1);
+    impl_tuples!(A 0, B 1, C 2);
+    impl_tuples!(A 0, B 1, C 2, D 3);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, U 19);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, U 19, V 20);
+};

--- a/src/methods/extrinsic_encoder/transaction_extensions.rs
+++ b/src/methods/extrinsic_encoder/transaction_extensions.rs
@@ -146,9 +146,7 @@ macro_rules! impl_tuples {
                                 // Protection: if we are returning an error then
                                 // no bytes should have been encoded to the given
                                 // Vec. Ensure that this is true:
-                                while out.len() > len {
-                                    out.pop();
-                                }
+                                out.truncate(len);
                                 TransactionExtensionsError::Other {
                                     extension_name: name.to_owned(),
                                     error: e,
@@ -176,9 +174,7 @@ macro_rules! impl_tuples {
                                 // Protection: if we are returning an error then
                                 // no bytes should have been encoded to the given
                                 // Vec. Ensure that this is true:
-                                while out.len() > len {
-                                    out.pop();
-                                }
+                                out.truncate(len);
                                 TransactionExtensionsError::Other {
                                     extension_name: name.to_owned(),
                                     error: e,
@@ -206,9 +202,7 @@ macro_rules! impl_tuples {
                                 // Protection: if we are returning an error then
                                 // no bytes should have been encoded to the given
                                 // Vec. Ensure that this is true:
-                                while out.len() > len {
-                                    out.pop();
-                                }
+                                out.truncate(len);
                                 TransactionExtensionsError::Other {
                                     extension_name: name.to_owned(),
                                     error: e,

--- a/src/methods/extrinsic_encoder/transaction_extensions.rs
+++ b/src/methods/extrinsic_encoder/transaction_extensions.rs
@@ -342,6 +342,11 @@ const _: () = {
     impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16);
     impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17);
     impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18);
-    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, U 19);
-    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, U 19, V 20);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21, W 22);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21, W 22, X 23);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21, W 22, X 23, Y 24);
+    impl_tuples!(A 0, B 1, C 2, D 3, E 4, F 5, G 6, H 7, I 8, J 9, K 10, L 11, M 12, N 13, O 14, P 15, Q 16, R 17, S 18, T 19, U 20, V 21, W 22, X 23, Y 24, Z 25);
 };

--- a/src/methods/extrinsic_encoder/transaction_extensions.rs
+++ b/src/methods/extrinsic_encoder/transaction_extensions.rs
@@ -71,11 +71,15 @@ pub trait TransactionExtensions<Resolver: TypeResolver> {
 /// This error will be returned if any of the methods in [`TransactionExtensions`] fail.
 #[derive(Debug, thiserror::Error)]
 pub enum TransactionExtensionsError {
+    /// The requested transaction extension could not be found.
     #[error("Cannot encode transaction extension '{0}': This extension could not be found")]
     NotFound(String),
+    /// An error occurred while encoding the transaction extension.
     #[error("Cannot encode transaction extension '{extension_name}': {error}")]
     Other {
+        /// The name of the extension that failed to encode.
         extension_name: String,
+        /// The underlying error.
         error: TransactionExtensionError,
     }
 }

--- a/src/methods/extrinsic_encoder/transaction_extensions.rs
+++ b/src/methods/extrinsic_encoder/transaction_extensions.rs
@@ -93,7 +93,7 @@ impl<Resolver: TypeResolver> TransactionExtensions<Resolver>
     for [&dyn TransactionExtension<Resolver>]
 {
     fn contains_extension(&self, name: &str) -> bool {
-        self.iter().find(|e| e.extension_name() == name).is_some()
+        self.iter().any(|e| e.extension_name() == name)
     }
 
     fn encode_extension_value_to(

--- a/src/methods/extrinsic_type_info.rs
+++ b/src/methods/extrinsic_type_info.rs
@@ -14,12 +14,9 @@
 // limitations under the License.
 
 use alloc::borrow::Cow;
-//use alloc::string::String;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::write;
-
-// #[cfg(feature = "legacy")]
-// use {crate::utils::as_decoded, scale_info_legacy::LookupName};
 
 /// Implementations of this are responsible for handing back the information we need to
 /// encode and decode extrinsics. This is expected to be implemented for runtime metadata
@@ -54,19 +51,19 @@ pub trait ExtrinsicTypeInfo {
     ) -> Result<ExtrinsicExtensionInfo<'_, Self::TypeId>, ExtrinsicInfoError<'_>>;
 
     /// Get the available transaction extension versions. Prior to runtimes supporting
-    /// V5 extrinsics this should not return any entries. In runtimes supporting V5 extrinsics, 
+    /// V5 extrinsics this should not return any entries. In runtimes supporting V5 extrinsics,
     /// 1 or more versions should be returned.
-    /// 
+    ///
     /// Versions should be returned in order from highest to lowest preference of
     /// whether they should be used for encoding extrinsics. The highest will be tried first,
     /// but if the relevant transaction extension information is not given then we will fall
     /// back to the next version until we find one we can satisfy.
-    /// 
+    ///
     /// All versions returned here should be passable to [`ExtrinsicTypeInfo::extrinsic_extension_info`]
     /// and return valid extensions information from that.
     fn extrinsic_extension_version_info(
         &self,
-    ) -> Result<impl Iterator<Item=u8>, ExtrinsicInfoError<'_>>;
+    ) -> Result<impl Iterator<Item = u8>, ExtrinsicInfoError<'_>>;
 }
 
 /// An error returned trying to access extrinsic type information.
@@ -636,7 +633,11 @@ impl ExtrinsicTypeInfo for frame_metadata::v16::RuntimeMetadataV16 {
     fn extrinsic_extension_version_info(
         &self,
     ) -> Result<impl Iterator<Item = u8>, ExtrinsicInfoError<'_>> {
-        Ok(self.extrinsic.transaction_extensions_by_version.keys().copied())
+        Ok(self
+            .extrinsic
+            .transaction_extensions_by_version
+            .keys()
+            .copied())
     }
 }
 
@@ -810,16 +811,18 @@ const _: () = {
 
             let calls = as_decoded(calls);
 
-            let (call_index, call) = calls.iter().enumerate().find(|(_, c)| {
-                let name: &str = as_decoded(&c.name).as_ref();
-                name == $call_name_arg
-            }).ok_or_else(|| {
-                ExtrinsicInfoError::CallNotFoundByName {
+            let (call_index, call) = calls
+                .iter()
+                .enumerate()
+                .find(|(_, c)| {
+                    let name: &str = as_decoded(&c.name).as_ref();
+                    name == $call_name_arg
+                })
+                .ok_or_else(|| ExtrinsicInfoError::CallNotFoundByName {
                     call_name: Cow::Owned($call_name_arg.to_string()),
                     pallet_index,
                     pallet_name: Cow::Borrowed(m_name),
-                }
-            })?;
+                })?;
 
             let c_name: &str = as_decoded(&call.name).as_ref();
 
@@ -1058,16 +1061,18 @@ const _: () = {
 
                     let calls = as_decoded(calls);
 
-                    let (call_index, call) = calls.iter().enumerate().find(|(_, c)| {
-                        let name: &str = as_decoded(&c.name).as_ref();
-                        name == call_name
-                    }).ok_or_else(|| {
-                        ExtrinsicInfoError::CallNotFoundByName {
+                    let (call_index, call) = calls
+                        .iter()
+                        .enumerate()
+                        .find(|(_, c)| {
+                            let name: &str = as_decoded(&c.name).as_ref();
+                            name == call_name
+                        })
+                        .ok_or_else(|| ExtrinsicInfoError::CallNotFoundByName {
                             call_name: Cow::Owned(call_name.to_string()),
                             pallet_index,
                             pallet_name: Cow::Borrowed(m_name),
-                        }
-                    })?;
+                        })?;
 
                     let c_name: &str = as_decoded(&call.name).as_ref();
 

--- a/src/methods/mod.rs
+++ b/src/methods/mod.rs
@@ -18,6 +18,7 @@ pub mod constant_type_info;
 pub mod custom_value_decoder;
 pub mod custom_value_type_info;
 pub mod extrinsic_decoder;
+pub mod extrinsic_encoder;
 pub mod extrinsic_type_info;
 pub mod runtime_api_decoder;
 pub mod runtime_api_encoder;

--- a/src/methods/storage_type_info.rs
+++ b/src/methods/storage_type_info.rs
@@ -17,7 +17,6 @@ use super::Entry;
 use crate::utils::Either;
 use alloc::borrow::Cow;
 use alloc::borrow::ToOwned;
-use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -462,6 +461,7 @@ to_latest_storage_hasher!(to_storage_hasher_v16, frame_metadata::v16::StorageHas
 mod legacy {
     use super::*;
     use crate::utils::as_decoded;
+    use alloc::format;
     use frame_metadata::decode_different::DecodeDifferent;
     use scale_info_legacy::LookupName;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,6 +17,7 @@ mod decodable_values;
 mod decode_with_error_tracing;
 mod either;
 mod encodable_values;
+#[cfg(feature = "legacy")]
 mod type_registry_from_metadata;
 
 pub use decodable_values::{DecodableValues, IntoDecodableValues};
@@ -24,6 +25,7 @@ pub use encodable_values::{EncodableValues, IntoEncodableValues};
 
 pub use decode_with_error_tracing::{DecodeErrorTrace, decode_with_error_tracing};
 pub use either::Either;
+
 #[cfg(feature = "legacy")]
 pub use type_registry_from_metadata::{
     ToTypeRegistry, type_registry_from_metadata, type_registry_from_metadata_any,

--- a/src/utils/type_registry_from_metadata.rs
+++ b/src/utils/type_registry_from_metadata.rs
@@ -24,7 +24,6 @@
 ///
 /// - `builtin::module::event::$PALLET` - A variant containing the events in a specific pallet.
 /// - `builtin::module::call::$PALLET` - A variant containing the calls in a specific pallet.
-#[cfg(feature = "legacy")]
 pub fn type_registry_from_metadata<Md: ToTypeRegistry>(
     metadata: &Md,
 ) -> Result<scale_info_legacy::TypeRegistry, scale_info_legacy::lookup_name::ParseError> {
@@ -33,7 +32,6 @@ pub fn type_registry_from_metadata<Md: ToTypeRegistry>(
 
 /// This is like [`type_registry_from_metadata`], except it can be handed the outer [`frame_metadata::RuntimeMetadata`]
 /// enum and will extract types from it where appropriate (handing back no types for deprecated or modern metadata).
-#[cfg(feature = "legacy")]
 pub fn type_registry_from_metadata_any(
     metadata: &frame_metadata::RuntimeMetadata,
 ) -> Result<scale_info_legacy::TypeRegistry, scale_info_legacy::lookup_name::ParseError> {
@@ -59,7 +57,6 @@ pub fn type_registry_from_metadata_any(
     }
 }
 
-#[cfg(feature = "legacy")]
 /// This is used with the [`type_registry_from_metadata`] helper function to extract types from the
 /// metadata. It is not intended to be implemented on anything else.
 pub trait ToTypeRegistry: sealed::Sealed {
@@ -73,7 +70,6 @@ mod sealed {
     pub trait Sealed {}
 }
 
-#[cfg(feature = "legacy")]
 const _: () = {
     use super::as_decoded;
     use alloc::borrow::ToOwned;


### PR DESCRIPTION
This PR adds the necessary methods to allow users to encode v4 and v5 unsigned and signed extrinsics, signer payloads and call data. It also adds `TransactionExtension` traits and handles the logic of selecting which transaction extensions to use, and extends `ExtrinsicTypeInfo` (and impls of this) as needed to make this all work.

The aim here is to make extrinsic encoding logic available in `no-std` contexts, and to get all of the logic for encoding and decoding storage/constants/runtime APIs/view functions/extrinsics in one place. Everything else was already in this crate, and with this extrinsic encode logic we complete the set.

**Note:** Subxt has been updated locally to work with this PR in [subxt#2177](https://github.com/paritytech/subxt/pull/2177) and as such we've tested the APIs (at least insofar as they are/were tested in Subxt) and verified that we have what we need. 

**Note 2:** As always, it would be good to get more testing moved to this crate. It's just typically been easier to do it in the Subxt crate since Subxt makes it easy to run E2E tests against some node to test things. See #2 for ideas on how to better test this crate.