### PR TITLE
Prep to release 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.17.1 (2025-02-23)
+
+- Fixed: update some Kusama types to fix decode issues ([#94](https://github.com/paritytech/frame-decode/pull/94)).
+
 ## 0.17.0 (2025-12-03)
 
 - Add extrinsic encode methods in `frame_decode::extrinsics`. This covers encoding v4 and v5 unsigned and signed extrinsics, new traits for providing transaction extensions, encoding v4 and v5 signer payloads and encoding call data.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "frame-metadata 23.0.1",
  "hex",
@@ -811,7 +811,7 @@ dependencies = [
 name = "frame-decode-tester"
 version = "0.1.0"
 dependencies = [
- "frame-decode 0.17.0",
+ "frame-decode 0.18.0",
  "frame-metadata 23.0.1",
  "hex",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"


### PR DESCRIPTION
- Fixed: update some Kusama types to fix decode issues ([#94](https://github.com/paritytech/frame-decode/pull/94)).