### PR TITLE
fix!: preserve V5 base implication in signer payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog].
 ## 0.18.0 (Unreleased)
 
 - Fix V5 signer payloads to hash the transaction extension version and call as an immutable base implication, followed by the explicit and implicit implications selected by authorization extensions such as `VerifyMultiSignature`.
-- Replace `encode_v5_signer_payload_with_info` with `encode_v5_signer_payload_with_info_and_version`, which requires the transaction extension version needed to construct a valid V5 signer payload.
+- Change `encode_v5_signer_payload_with_info` to require the transaction extension version needed to construct a valid V5 signer payload.
 
 ## 0.17.2 (2026-03-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## Unreleased
+
+- Fix V5 signer payloads to hash the transaction extension version and call as an immutable base implication, followed by the explicit and implicit implications selected by authorization extensions such as `VerifyMultiSignature`.
+- Add `encode_v5_signer_payload_with_info_and_version`; deprecate `encode_v5_signer_payload_with_info`, which cannot represent nonzero transaction extension versions.
+
 ## 0.17.2 (2026-03-12)
 
 - When encoding extrinsics, unknown Transaction Extensions that are `Option<SomeType>` will now be accepted, and encoded as `0u8` (ie the `None` variant) by default if an extension with the corresponding name is not provided by the user. This allows transaction encoding to succeed in more cases, such as when a bunch of optional extensions exist for a chian, but still allows the user to properly implement and provide those extensions if they wish.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## Unreleased
+## 0.18.0 (Unreleased)
 
 - Fix V5 signer payloads to hash the transaction extension version and call as an immutable base implication, followed by the explicit and implicit implications selected by authorization extensions such as `VerifyMultiSignature`.
-- Add `encode_v5_signer_payload_with_info_and_version`; deprecate `encode_v5_signer_payload_with_info`, which cannot represent nonzero transaction extension versions.
+- Replace `encode_v5_signer_payload_with_info` with `encode_v5_signer_payload_with_info_and_version`, which requires the transaction extension version needed to construct a valid V5 signer payload.
 
 ## 0.17.2 (2026-03-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog].
 
 ## 0.18.0 (Unreleased)
 
-- Fix V5 signer payloads to hash the transaction extension version and call as an immutable base implication, followed by the explicit and implicit implications selected by authorization extensions such as `VerifyMultiSignature`.
+- Fix V5 signer payloads to hash the transaction extension version and call, followed by the extension values and implicits of only the extensions after the last authorization extension (such as `VerifyMultiSignature`), matching FRAME's transaction extension pipeline semantics.
+- Add `TransactionExtension::is_authorization_extension` (and the corresponding `TransactionExtensions` method), which extensions like `VerifyMultiSignature` should override to return `true`. It defaults to `false`.
+- Remove `TransactionExtension::encode_value_for_signer_payload_to` and `TransactionExtensions::encode_extension_value_for_signer_payload_to`; extension values are now encoded identically in transactions and signer payloads, with authorization extensions excluded via `is_authorization_extension` instead.
 - Change `encode_v5_signer_payload_with_info` to require the transaction extension version needed to construct a valid V5 signer payload.
 
 ## 0.17.2 (2026-03-12)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "frame-metadata 23.0.1",
  "hex",
@@ -811,7 +811,7 @@ dependencies = [
 name = "frame-decode-tester"
 version = "0.1.0"
 dependencies = [
- "frame-decode 0.17.2",
+ "frame-decode 0.18.0",
  "frame-metadata 23.0.1",
  "hex",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.17.2"
+version = "0.18.0"
 edition = "2024"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ pub mod extrinsics {
         Extrinsic, ExtrinsicDecodeError, ExtrinsicExtensions, ExtrinsicOwned, ExtrinsicSignature,
         ExtrinsicType, NamedArg, decode_extrinsic,
     };
-    #[allow(deprecated)]
     pub use crate::methods::extrinsic_encoder::{
         ExtrinsicEncodeError, TransactionExtension, TransactionExtensionError,
         TransactionExtensions, TransactionExtensionsError,
@@ -50,7 +49,7 @@ pub mod extrinsics {
         encode_v4_unsigned_with_info_to, encode_v5_bare, encode_v5_bare_to,
         encode_v5_bare_with_info_to, encode_v5_general, encode_v5_general_to,
         encode_v5_general_with_info_to, encode_v5_signer_payload,
-        encode_v5_signer_payload_with_info, encode_v5_signer_payload_with_info_and_version,
+        encode_v5_signer_payload_with_info_and_version,
     };
     pub use crate::methods::extrinsic_type_info::{
         ExtrinsicCallInfo, ExtrinsicCallInfoArg, ExtrinsicExtensionInfo, ExtrinsicExtensionInfoArg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod extrinsics {
         Extrinsic, ExtrinsicDecodeError, ExtrinsicExtensions, ExtrinsicOwned, ExtrinsicSignature,
         ExtrinsicType, NamedArg, decode_extrinsic,
     };
+    #[allow(deprecated)]
     pub use crate::methods::extrinsic_encoder::{
         ExtrinsicEncodeError, TransactionExtension, TransactionExtensionError,
         TransactionExtensions, TransactionExtensionsError,
@@ -49,7 +50,7 @@ pub mod extrinsics {
         encode_v4_unsigned_with_info_to, encode_v5_bare, encode_v5_bare_to,
         encode_v5_bare_with_info_to, encode_v5_general, encode_v5_general_to,
         encode_v5_general_with_info_to, encode_v5_signer_payload,
-        encode_v5_signer_payload_with_info,
+        encode_v5_signer_payload_with_info, encode_v5_signer_payload_with_info_and_version,
     };
     pub use crate::methods::extrinsic_type_info::{
         ExtrinsicCallInfo, ExtrinsicCallInfoArg, ExtrinsicExtensionInfo, ExtrinsicExtensionInfoArg,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod extrinsics {
         encode_v4_unsigned_with_info_to, encode_v5_bare, encode_v5_bare_to,
         encode_v5_bare_with_info_to, encode_v5_general, encode_v5_general_to,
         encode_v5_general_with_info_to, encode_v5_signer_payload,
-        encode_v5_signer_payload_with_info_and_version,
+        encode_v5_signer_payload_with_info,
     };
     pub use crate::methods::extrinsic_type_info::{
         ExtrinsicCallInfo, ExtrinsicCallInfoArg, ExtrinsicExtensionInfo, ExtrinsicExtensionInfoArg,

--- a/src/methods/extrinsic_encoder.rs
+++ b/src/methods/extrinsic_encoder.rs
@@ -1002,7 +1002,7 @@ where
         .map_err(|i| i.into_owned())
         .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
 
-    encode_v5_signer_payload_with_info_and_version(
+    encode_v5_signer_payload_with_info(
         call_data,
         transaction_extension_version,
         transaction_extensions,
@@ -1022,7 +1022,7 @@ where
 /// base implication, followed by the transaction extension values (for the signer payload) and
 /// transaction extension implicit data. The result is always hashed using Blake2-256, returning a
 /// fixed 32-byte array.
-pub fn encode_v5_signer_payload_with_info_and_version<CallData, Resolver, Exts>(
+pub fn encode_v5_signer_payload_with_info<CallData, Resolver, Exts>(
     call_data: &CallData,
     transaction_extension_version: u8,
     transaction_extensions: &Exts,
@@ -1560,7 +1560,7 @@ mod test {
             args: Vec::new(),
         };
 
-        let actual = encode_v5_signer_payload_with_info_and_version(
+        let actual = encode_v5_signer_payload_with_info(
             &(),
             7,
             &extensions,

--- a/src/methods/extrinsic_encoder.rs
+++ b/src/methods/extrinsic_encoder.rs
@@ -386,6 +386,7 @@ where
         ext_info,
         transaction_extensions,
         type_resolver,
+        TransactionExtensionValuesTarget::Extrinsic,
         &mut encoded_inner,
     )
     .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
@@ -495,8 +496,14 @@ where
     encode_call_data_with_info_to(call_data, call_info, type_resolver, &mut out)?;
 
     // Then the signer payload value (ie roughly the bytes that will appear in the tx)
-    encode_transaction_extension_values(ext_info, transaction_extensions, type_resolver, &mut out)
-        .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
+    encode_transaction_extension_values(
+        ext_info,
+        transaction_extensions,
+        type_resolver,
+        TransactionExtensionValuesTarget::SignerPayload,
+        &mut out,
+    )
+    .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
 
     // Then the signer payload implicits (ie data we want to verify that is NOT in the tx)
     encode_transaction_extension_implicits(
@@ -910,6 +917,7 @@ where
         ext_info,
         transaction_extensions,
         type_resolver,
+        TransactionExtensionValuesTarget::Extrinsic,
         &mut encoded_inner,
     )
     .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
@@ -925,8 +933,9 @@ where
 /// Encode the signer payload for a V5 general extrinsic.
 ///
 /// The signer payload is the data that should be signed to produce the signature for
-/// a general extrinsic. It consists of the encoded call data, the transaction extension
-/// values (for the signer payload), and the transaction extension implicit data.
+/// a general extrinsic. It consists of the transaction extension version and encoded call data as
+/// its base implication, followed by the transaction extension values (for the signer payload)
+/// and transaction extension implicit data.
 ///
 /// Unlike [`encode_v4_signer_payload`], which conditionally hashes the payload if it exceeds
 /// 256 bytes, V5 signer payloads are always hashed using Blake2-256, returning a fixed 32-byte
@@ -993,8 +1002,9 @@ where
         .map_err(|i| i.into_owned())
         .map_err(ExtrinsicEncodeError::CannotGetInfo)?;
 
-    encode_v5_signer_payload_with_info(
+    encode_v5_signer_payload_with_info_and_version(
         call_data,
+        transaction_extension_version,
         transaction_extensions,
         type_resolver,
         &call_info,
@@ -1008,9 +1018,68 @@ where
 /// given the pallet and call names, this function takes these as arguments. This is useful if you
 /// already have this information available.
 ///
-/// The signer payload consists of the encoded call data, the transaction extension values
-/// (for the signer payload), and the transaction extension implicit data. The result is always
-/// hashed using Blake2-256, returning a fixed 32-byte array.
+/// The signer payload consists of the transaction extension version and encoded call data as its
+/// base implication, followed by the transaction extension values (for the signer payload) and
+/// transaction extension implicit data. The result is always hashed using Blake2-256, returning a
+/// fixed 32-byte array.
+pub fn encode_v5_signer_payload_with_info_and_version<CallData, Resolver, Exts>(
+    call_data: &CallData,
+    transaction_extension_version: u8,
+    transaction_extensions: &Exts,
+    type_resolver: &Resolver,
+    call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
+    ext_info: &ExtrinsicExtensionInfo<Resolver::TypeId>,
+) -> Result<[u8; 32], ExtrinsicEncodeError>
+where
+    CallData: EncodeAsFields,
+    Resolver: TypeResolver,
+    Exts: TransactionExtensions<Resolver>,
+{
+    let mut base = Vec::new();
+
+    // The base implication always remains part of the signer payload, even if an extension
+    // discards earlier extension implications.
+    transaction_extension_version.encode_to(&mut base);
+    encode_call_data_with_info_to(call_data, call_info, type_resolver, &mut base)?;
+
+    // Encode explicit and implicit implications separately. An authorization extension may clear
+    // either output to exclude preceding extensions, but must not be able to clear the base or the
+    // other implication section.
+    let mut explicit = Vec::new();
+    encode_transaction_extension_values(
+        ext_info,
+        transaction_extensions,
+        type_resolver,
+        TransactionExtensionValuesTarget::SignerPayload,
+        &mut explicit,
+    )
+    .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
+
+    let mut implicit = Vec::new();
+    encode_transaction_extension_implicits(
+        ext_info,
+        transaction_extensions,
+        type_resolver,
+        &mut implicit,
+    )
+    .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
+
+    base.extend(explicit);
+    base.extend(implicit);
+
+    // V5 signer payloads are always hashed, regardless of length.
+    Ok(sp_crypto_hashing::blake2_256(&base))
+}
+
+/// Encode the signer payload for a V5 general extrinsic at transaction extension version 0,
+/// using pre-computed type information.
+///
+/// Use [`encode_v5_signer_payload_with_info_and_version`] when the transaction extension version
+/// is available. The version is part of the V5 base implication and therefore must be included in
+/// the signer payload.
+#[deprecated(
+    note = "Use encode_v5_signer_payload_with_info_and_version; this function assumes transaction extension version 0"
+)]
 pub fn encode_v5_signer_payload_with_info<CallData, Resolver, Exts>(
     call_data: &CallData,
     transaction_extensions: &Exts,
@@ -1023,26 +1092,14 @@ where
     Resolver: TypeResolver,
     Exts: TransactionExtensions<Resolver>,
 {
-    let mut out = Vec::new();
-
-    // First encode call data
-    encode_call_data_with_info_to(call_data, call_info, type_resolver, &mut out)?;
-
-    // Then the signer payload value (ie roughly the bytes that will appear in the tx)
-    encode_transaction_extension_values(ext_info, transaction_extensions, type_resolver, &mut out)
-        .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
-
-    // Then the signer payload implicits (ie data we want to verify that is NOT in the tx)
-    encode_transaction_extension_implicits(
-        ext_info,
+    encode_v5_signer_payload_with_info_and_version(
+        call_data,
+        0,
         transaction_extensions,
         type_resolver,
-        &mut out,
+        call_info,
+        ext_info,
     )
-    .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
-
-    // Finally hash it (regardless of length).
-    Ok(sp_crypto_hashing::blake2_256(&out))
 }
 
 /// Encode the call data for an extrinsic.
@@ -1181,6 +1238,12 @@ enum TransactionVersion {
     V5 = 5u8,
 }
 
+#[derive(Copy, Clone)]
+enum TransactionExtensionValuesTarget {
+    Extrinsic,
+    SignerPayload,
+}
+
 /// Encode the transaction extension values to the provided output in the order given by
 /// the [`ExtrinsicExtensionInfo`]. We skip missing extensions that would encode as 0 bytes,
 /// and we encode a 0u8 for any missing extensions whose value is an `Option<T>`, which
@@ -1189,6 +1252,7 @@ fn encode_transaction_extension_values<'exts, 'info, Resolver, Exts>(
     ext_info: &'exts ExtrinsicExtensionInfo<'info, <Resolver as TypeResolver>::TypeId>,
     transaction_extensions: &Exts,
     type_resolver: &Resolver,
+    target: TransactionExtensionValuesTarget,
     out: &mut Vec<u8>,
 ) -> Result<(), TransactionExtensionsError>
 where
@@ -1198,12 +1262,20 @@ where
     let nonempty_values = ext_info
         .extension_ids
         .iter()
-        .filter(|arg| !is_type_empty(arg.id.clone(), type_resolver))
+        .filter(|arg| {
+            !is_type_empty(arg.id.clone(), type_resolver)
+                || matches!(target, TransactionExtensionValuesTarget::SignerPayload)
+                    && transaction_extensions.contains_extension(&arg.name)
+        })
         .map(|arg| (&*arg.name, arg.id.clone()));
 
     for (name, id) in nonempty_values {
-        let res =
-            transaction_extensions.encode_extension_value_to(name, id.clone(), type_resolver, out);
+        let res = match target {
+            TransactionExtensionValuesTarget::Extrinsic => transaction_extensions
+                .encode_extension_value_to(name, id.clone(), type_resolver, out),
+            TransactionExtensionValuesTarget::SignerPayload => transaction_extensions
+                .encode_extension_value_for_signer_payload_to(name, id.clone(), type_resolver, out),
+        };
 
         match res {
             // All ok
@@ -1238,7 +1310,10 @@ where
     let nonempty_implicits = ext_info
         .extension_ids
         .iter()
-        .filter(|arg| !is_type_empty(arg.implicit_id.clone(), type_resolver))
+        .filter(|arg| {
+            !is_type_empty(arg.implicit_id.clone(), type_resolver)
+                || transaction_extensions.contains_extension(&arg.name)
+        })
         .map(|arg| (&*arg.name, arg.implicit_id.clone()));
 
     for (name, id) in nonempty_implicits {
@@ -1413,6 +1488,46 @@ mod test {
     make_test_extension!(Extension1                      value=(bool, u64),           implicit=bool);
     make_test_extension!(Extension2                      value=String,                implicit=());
 
+    struct VerifyMultiSignature;
+
+    impl GetTestExtensionTypes for VerifyMultiSignature {
+        type Value = ();
+        type Implicit = ();
+    }
+
+    impl TransactionExtension<PortableRegistry> for VerifyMultiSignature {
+        const NAME: &str = "VerifyMultiSignature";
+
+        fn encode_value_to(
+            &self,
+            _type_id: u32,
+            _type_resolver: &PortableRegistry,
+            _out: &mut Vec<u8>,
+        ) -> Result<(), TransactionExtensionError> {
+            Ok(())
+        }
+
+        fn encode_value_for_signer_payload_to(
+            &self,
+            _type_id: u32,
+            _type_resolver: &PortableRegistry,
+            out: &mut Vec<u8>,
+        ) -> Result<(), TransactionExtensionError> {
+            out.clear();
+            Ok(())
+        }
+
+        fn encode_implicit_to(
+            &self,
+            _type_id: u32,
+            _type_resolver: &PortableRegistry,
+            out: &mut Vec<u8>,
+        ) -> Result<(), TransactionExtensionError> {
+            out.clear();
+            Ok(())
+        }
+    }
+
     /// Returns an ExtrinsicExtensionInfo vec given some set of test transaction extensions, as well
     /// as the PortableRegistry needed to resolve those types properly.
     macro_rules! make_extension_info {
@@ -1450,6 +1565,51 @@ mod test {
     // -------------------------- And now the actual tests --------------------------
 
     #[test]
+    fn v5_signer_payload_encodes_the_runtime_implication() {
+        let (extension_info, types) = make_extension_info![
+            Extension1,
+            ExtensionContainingNothing,
+            VerifyMultiSignature,
+            ExtensionContainingOption,
+        ];
+        let extensions = (
+            Extension1 {
+                value: (true, 123),
+                implicit: false,
+            },
+            VerifyMultiSignature,
+            ExtensionContainingOption {
+                value: Some(true),
+                implicit: 12345,
+            },
+        );
+        let call_info = ExtrinsicCallInfo {
+            pallet_index: 1,
+            call_index: 2,
+            pallet_name: "Test".into(),
+            call_name: "call".into(),
+            args: Vec::new(),
+        };
+
+        let actual = encode_v5_signer_payload_with_info_and_version(
+            &(),
+            7,
+            &extensions,
+            &types,
+            &call_info,
+            &extension_info,
+        )
+        .unwrap();
+
+        // Mirrors TxBaseImplication((extension_version, call)) followed by the explicit and
+        // implicit implications strictly after VerifyMultiSignature.
+        let expected_preimage = (7u8, 1u8, 2u8, Some(true), 12345u64).encode();
+        let expected = sp_crypto_hashing::blake2_256(&expected_preimage);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn encode_transaction_extension_values_basic() {
         let (info, types) = make_extension_info![Extension1, Extension2,];
 
@@ -1465,8 +1625,14 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_values(&info, &exts, &types, &mut out)
-            .expect("Encoding should succeed");
+        encode_transaction_extension_values(
+            &info,
+            &exts,
+            &types,
+            TransactionExtensionValuesTarget::Extrinsic,
+            &mut out,
+        )
+        .expect("Encoding should succeed");
         assert_decodes_into(&out, (true, 123u64, "Hello".to_owned()));
     }
 
@@ -1486,8 +1652,14 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_values(&info, &exts, &types, &mut out)
-            .expect("Encoding should succeed");
+        encode_transaction_extension_values(
+            &info,
+            &exts,
+            &types,
+            TransactionExtensionValuesTarget::Extrinsic,
+            &mut out,
+        )
+        .expect("Encoding should succeed");
         assert_decodes_into(&out, (true, 123u64, "Hello".to_owned()));
     }
 
@@ -1508,8 +1680,14 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_values(&info, &exts, &types, &mut out)
-            .expect("Encoding should succeed despite Option");
+        encode_transaction_extension_values(
+            &info,
+            &exts,
+            &types,
+            TransactionExtensionValuesTarget::Extrinsic,
+            &mut out,
+        )
+        .expect("Encoding should succeed despite Option");
         assert_decodes_into(&out, (true, 123u64, "Hello".to_owned()));
     }
 
@@ -1534,8 +1712,14 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_values(&info, &exts, &types, &mut out)
-            .expect("Encoding should succeed despite Option");
+        encode_transaction_extension_values(
+            &info,
+            &exts,
+            &types,
+            TransactionExtensionValuesTarget::Extrinsic,
+            &mut out,
+        )
+        .expect("Encoding should succeed despite Option");
         assert_decodes_into(&out, (true, 123u64, 0u8, 0u8, "Hello".to_owned()));
     }
 

--- a/src/methods/extrinsic_encoder.rs
+++ b/src/methods/extrinsic_encoder.rs
@@ -1071,37 +1071,6 @@ where
     Ok(sp_crypto_hashing::blake2_256(&base))
 }
 
-/// Encode the signer payload for a V5 general extrinsic at transaction extension version 0,
-/// using pre-computed type information.
-///
-/// Use [`encode_v5_signer_payload_with_info_and_version`] when the transaction extension version
-/// is available. The version is part of the V5 base implication and therefore must be included in
-/// the signer payload.
-#[deprecated(
-    note = "Use encode_v5_signer_payload_with_info_and_version; this function assumes transaction extension version 0"
-)]
-pub fn encode_v5_signer_payload_with_info<CallData, Resolver, Exts>(
-    call_data: &CallData,
-    transaction_extensions: &Exts,
-    type_resolver: &Resolver,
-    call_info: &ExtrinsicCallInfo<Resolver::TypeId>,
-    ext_info: &ExtrinsicExtensionInfo<Resolver::TypeId>,
-) -> Result<[u8; 32], ExtrinsicEncodeError>
-where
-    CallData: EncodeAsFields,
-    Resolver: TypeResolver,
-    Exts: TransactionExtensions<Resolver>,
-{
-    encode_v5_signer_payload_with_info_and_version(
-        call_data,
-        0,
-        transaction_extensions,
-        type_resolver,
-        call_info,
-        ext_info,
-    )
-}
-
 /// Encode the call data for an extrinsic.
 ///
 /// This is basically an alias for [`scale_encode::EncodeAsFields::encode_as_fields()`].

--- a/src/methods/extrinsic_encoder.rs
+++ b/src/methods/extrinsic_encoder.rs
@@ -16,8 +16,8 @@
 mod transaction_extension;
 mod transaction_extensions;
 use super::extrinsic_type_info::{
-    ExtrinsicCallInfo, ExtrinsicExtensionInfo, ExtrinsicInfoError, ExtrinsicSignatureInfo,
-    ExtrinsicTypeInfo,
+    ExtrinsicCallInfo, ExtrinsicExtensionInfo, ExtrinsicExtensionInfoArg, ExtrinsicInfoError,
+    ExtrinsicSignatureInfo, ExtrinsicTypeInfo,
 };
 use alloc::vec::Vec;
 use parity_scale_codec::Encode;
@@ -383,10 +383,9 @@ where
 
     // Signed extensions (now Transaction Extensions)
     encode_transaction_extension_values(
-        ext_info,
+        &ext_info.extension_ids,
         transaction_extensions,
         type_resolver,
-        TransactionExtensionValuesTarget::Extrinsic,
         &mut encoded_inner,
     )
     .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
@@ -497,17 +496,16 @@ where
 
     // Then the signer payload value (ie roughly the bytes that will appear in the tx)
     encode_transaction_extension_values(
-        ext_info,
+        &ext_info.extension_ids,
         transaction_extensions,
         type_resolver,
-        TransactionExtensionValuesTarget::SignerPayload,
         &mut out,
     )
     .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
 
     // Then the signer payload implicits (ie data we want to verify that is NOT in the tx)
     encode_transaction_extension_implicits(
-        ext_info,
+        &ext_info.extension_ids,
         transaction_extensions,
         type_resolver,
         &mut out,
@@ -914,10 +912,9 @@ where
 
     // Transaction Extensions next. These may include a signature/address
     encode_transaction_extension_values(
-        ext_info,
+        &ext_info.extension_ids,
         transaction_extensions,
         type_resolver,
-        TransactionExtensionValuesTarget::Extrinsic,
         &mut encoded_inner,
     )
     .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
@@ -933,9 +930,10 @@ where
 /// Encode the signer payload for a V5 general extrinsic.
 ///
 /// The signer payload is the data that should be signed to produce the signature for
-/// a general extrinsic. It consists of the transaction extension version and encoded call data as
-/// its base implication, followed by the transaction extension values (for the signer payload)
-/// and transaction extension implicit data.
+/// a general extrinsic. It consists of the transaction extension version and encoded call data,
+/// followed by the transaction extension values and implicit data of the extensions after the
+/// last authorization extension (see [`TransactionExtension::is_authorization_extension`]);
+/// an authorization extension signs only the implications which follow it.
 ///
 /// Unlike [`encode_v4_signer_payload`], which conditionally hashes the payload if it exceeds
 /// 256 bytes, V5 signer payloads are always hashed using Blake2-256, returning a fixed 32-byte
@@ -1018,10 +1016,10 @@ where
 /// given the pallet and call names, this function takes these as arguments. This is useful if you
 /// already have this information available.
 ///
-/// The signer payload consists of the transaction extension version and encoded call data as its
-/// base implication, followed by the transaction extension values (for the signer payload) and
-/// transaction extension implicit data. The result is always hashed using Blake2-256, returning a
-/// fixed 32-byte array.
+/// The signer payload consists of the transaction extension version and encoded call data,
+/// followed by the transaction extension values and implicit data of the extensions after the
+/// last authorization extension (see [`TransactionExtension::is_authorization_extension`]).
+/// The result is always hashed using Blake2-256, returning a fixed 32-byte array.
 pub fn encode_v5_signer_payload_with_info<CallData, Resolver, Exts>(
     call_data: &CallData,
     transaction_extension_version: u8,
@@ -1035,40 +1033,43 @@ where
     Resolver: TypeResolver,
     Exts: TransactionExtensions<Resolver>,
 {
-    let mut base = Vec::new();
+    let mut payload = Vec::new();
 
-    // The base implication always remains part of the signer payload, even if an extension
-    // discards earlier extension implications.
-    transaction_extension_version.encode_to(&mut base);
-    encode_call_data_with_info_to(call_data, call_info, type_resolver, &mut base)?;
+    // First, the base implication: the transaction extension version and call data.
+    // This is always signed, regardless of any authorization extension below.
+    transaction_extension_version.encode_to(&mut payload);
+    encode_call_data_with_info_to(call_data, call_info, type_resolver, &mut payload)?;
 
-    // Encode explicit and implicit implications separately. An authorization extension may clear
-    // either output to exclude preceding extensions, but must not be able to clear the base or the
-    // other implication section.
-    let mut explicit = Vec::new();
+    // An authorization extension (eg VerifyMultiSignature) signs only the implications of the
+    // extensions following it, so it and every extension before it contribute no bytes to the
+    // signer payload.
+    let signed_extension_ids = ext_info
+        .extension_ids
+        .iter()
+        .rposition(|e| transaction_extensions.is_authorization_extension(&e.name))
+        .map(|last_auth| &ext_info.extension_ids[last_auth + 1..])
+        .unwrap_or(&ext_info.extension_ids);
+
+    // Then the signer payload values (ie roughly the bytes that will appear in the tx)
     encode_transaction_extension_values(
-        ext_info,
+        signed_extension_ids,
         transaction_extensions,
         type_resolver,
-        TransactionExtensionValuesTarget::SignerPayload,
-        &mut explicit,
+        &mut payload,
     )
     .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
 
-    let mut implicit = Vec::new();
+    // Then the signer payload implicits (ie data we want to verify that is NOT in the tx)
     encode_transaction_extension_implicits(
-        ext_info,
+        signed_extension_ids,
         transaction_extensions,
         type_resolver,
-        &mut implicit,
+        &mut payload,
     )
     .map_err(ExtrinsicEncodeError::TransactionExtensions)?;
-
-    base.extend(explicit);
-    base.extend(implicit);
 
     // V5 signer payloads are always hashed, regardless of length.
-    Ok(sp_crypto_hashing::blake2_256(&base))
+    Ok(sp_crypto_hashing::blake2_256(&payload))
 }
 
 /// Encode the call data for an extrinsic.
@@ -1207,44 +1208,29 @@ enum TransactionVersion {
     V5 = 5u8,
 }
 
-#[derive(Copy, Clone)]
-enum TransactionExtensionValuesTarget {
-    Extrinsic,
-    SignerPayload,
-}
-
 /// Encode the transaction extension values to the provided output in the order given by
-/// the [`ExtrinsicExtensionInfo`]. We skip missing extensions that would encode as 0 bytes,
-/// and we encode a 0u8 for any missing extensions whose value is an `Option<T>`, which
-/// carries the assumption that the default value for such an extension is `None`.
-fn encode_transaction_extension_values<'exts, 'info, Resolver, Exts>(
-    ext_info: &'exts ExtrinsicExtensionInfo<'info, <Resolver as TypeResolver>::TypeId>,
+/// the extension args from an [`ExtrinsicExtensionInfo`]. We skip missing extensions that
+/// would encode as 0 bytes, and we encode a 0u8 for any missing extensions whose value is
+/// an `Option<T>`, which carries the assumption that the default value for such an extension
+/// is `None`.
+fn encode_transaction_extension_values<Resolver, Exts>(
+    extension_ids: &[ExtrinsicExtensionInfoArg<'_, <Resolver as TypeResolver>::TypeId>],
     transaction_extensions: &Exts,
     type_resolver: &Resolver,
-    target: TransactionExtensionValuesTarget,
     out: &mut Vec<u8>,
 ) -> Result<(), TransactionExtensionsError>
 where
     Resolver: TypeResolver,
     Exts: TransactionExtensions<Resolver>,
 {
-    let nonempty_values = ext_info
-        .extension_ids
+    let nonempty_values = extension_ids
         .iter()
-        .filter(|arg| {
-            !is_type_empty(arg.id.clone(), type_resolver)
-                || matches!(target, TransactionExtensionValuesTarget::SignerPayload)
-                    && transaction_extensions.contains_extension(&arg.name)
-        })
+        .filter(|arg| !is_type_empty(arg.id.clone(), type_resolver))
         .map(|arg| (&*arg.name, arg.id.clone()));
 
     for (name, id) in nonempty_values {
-        let res = match target {
-            TransactionExtensionValuesTarget::Extrinsic => transaction_extensions
-                .encode_extension_value_to(name, id.clone(), type_resolver, out),
-            TransactionExtensionValuesTarget::SignerPayload => transaction_extensions
-                .encode_extension_value_for_signer_payload_to(name, id.clone(), type_resolver, out),
-        };
+        let res =
+            transaction_extensions.encode_extension_value_to(name, id.clone(), type_resolver, out);
 
         match res {
             // All ok
@@ -1265,9 +1251,10 @@ where
 }
 
 /// Encode the transaction extension implicits to the provided output in the order given by
-/// the [`ExtrinsicExtensionInfo`]. We skip missing extensions whose implicit would encode as 0 bytes.
-fn encode_transaction_extension_implicits<'exts, 'info, Resolver, Exts>(
-    ext_info: &'exts ExtrinsicExtensionInfo<'info, <Resolver as TypeResolver>::TypeId>,
+/// the extension args from an [`ExtrinsicExtensionInfo`]. We skip missing extensions whose
+/// implicit would encode as 0 bytes.
+fn encode_transaction_extension_implicits<Resolver, Exts>(
+    extension_ids: &[ExtrinsicExtensionInfoArg<'_, <Resolver as TypeResolver>::TypeId>],
     transaction_extensions: &Exts,
     type_resolver: &Resolver,
     out: &mut Vec<u8>,
@@ -1276,13 +1263,9 @@ where
     Resolver: TypeResolver,
     Exts: TransactionExtensions<Resolver>,
 {
-    let nonempty_implicits = ext_info
-        .extension_ids
+    let nonempty_implicits = extension_ids
         .iter()
-        .filter(|arg| {
-            !is_type_empty(arg.implicit_id.clone(), type_resolver)
-                || transaction_extensions.contains_extension(&arg.name)
-        })
+        .filter(|arg| !is_type_empty(arg.implicit_id.clone(), type_resolver))
         .map(|arg| (&*arg.name, arg.implicit_id.clone()));
 
     for (name, id) in nonempty_implicits {
@@ -1457,6 +1440,8 @@ mod test {
     make_test_extension!(Extension1                      value=(bool, u64),           implicit=bool);
     make_test_extension!(Extension2                      value=String,                implicit=());
 
+    /// A test extension which authorizes the transaction, standing in for
+    /// something like the real `VerifyMultiSignature` extension.
     struct VerifyMultiSignature;
 
     impl GetTestExtensionTypes for VerifyMultiSignature {
@@ -1467,6 +1452,10 @@ mod test {
     impl TransactionExtension<PortableRegistry> for VerifyMultiSignature {
         const NAME: &str = "VerifyMultiSignature";
 
+        fn is_authorization_extension(&self) -> bool {
+            true
+        }
+
         fn encode_value_to(
             &self,
             _type_id: u32,
@@ -1476,23 +1465,12 @@ mod test {
             Ok(())
         }
 
-        fn encode_value_for_signer_payload_to(
-            &self,
-            _type_id: u32,
-            _type_resolver: &PortableRegistry,
-            out: &mut Vec<u8>,
-        ) -> Result<(), TransactionExtensionError> {
-            out.clear();
-            Ok(())
-        }
-
         fn encode_implicit_to(
             &self,
             _type_id: u32,
             _type_resolver: &PortableRegistry,
-            out: &mut Vec<u8>,
+            _out: &mut Vec<u8>,
         ) -> Result<(), TransactionExtensionError> {
-            out.clear();
             Ok(())
         }
     }
@@ -1594,14 +1572,8 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_values(
-            &info,
-            &exts,
-            &types,
-            TransactionExtensionValuesTarget::Extrinsic,
-            &mut out,
-        )
-        .expect("Encoding should succeed");
+        encode_transaction_extension_values(&info.extension_ids, &exts, &types, &mut out)
+            .expect("Encoding should succeed");
         assert_decodes_into(&out, (true, 123u64, "Hello".to_owned()));
     }
 
@@ -1621,14 +1593,8 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_values(
-            &info,
-            &exts,
-            &types,
-            TransactionExtensionValuesTarget::Extrinsic,
-            &mut out,
-        )
-        .expect("Encoding should succeed");
+        encode_transaction_extension_values(&info.extension_ids, &exts, &types, &mut out)
+            .expect("Encoding should succeed");
         assert_decodes_into(&out, (true, 123u64, "Hello".to_owned()));
     }
 
@@ -1649,14 +1615,8 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_values(
-            &info,
-            &exts,
-            &types,
-            TransactionExtensionValuesTarget::Extrinsic,
-            &mut out,
-        )
-        .expect("Encoding should succeed despite Option");
+        encode_transaction_extension_values(&info.extension_ids, &exts, &types, &mut out)
+            .expect("Encoding should succeed despite Option");
         assert_decodes_into(&out, (true, 123u64, "Hello".to_owned()));
     }
 
@@ -1681,14 +1641,8 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_values(
-            &info,
-            &exts,
-            &types,
-            TransactionExtensionValuesTarget::Extrinsic,
-            &mut out,
-        )
-        .expect("Encoding should succeed despite Option");
+        encode_transaction_extension_values(&info.extension_ids, &exts, &types, &mut out)
+            .expect("Encoding should succeed despite Option");
         assert_decodes_into(&out, (true, 123u64, 0u8, 0u8, "Hello".to_owned()));
     }
 
@@ -1713,7 +1667,7 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_implicits(&info, &exts, &types, &mut out)
+        encode_transaction_extension_implicits(&info.extension_ids, &exts, &types, &mut out)
             .expect("Encoding should succeed");
         assert_decodes_into(&out, (false, 12345u64));
     }
@@ -1739,7 +1693,7 @@ mod test {
         );
 
         let mut out = vec![];
-        encode_transaction_extension_implicits(&info, &exts, &types, &mut out)
+        encode_transaction_extension_implicits(&info.extension_ids, &exts, &types, &mut out)
             .expect("Encoding should succeed");
         assert_decodes_into(&out, (false, 12345u64));
     }

--- a/src/methods/extrinsic_encoder/transaction_extension.rs
+++ b/src/methods/extrinsic_encoder/transaction_extension.rs
@@ -24,6 +24,19 @@ pub trait TransactionExtension<Resolver: TypeResolver> {
     /// The name of this transaction extension.
     const NAME: &str;
 
+    /// Does this extension authorize the transaction, eg by containing a signature
+    /// like `VerifyMultiSignature` does? Such an extension signs the transaction
+    /// extension version, the call data, and the values and implicits of only the
+    /// extensions _after_ it, and so when a V5 signer payload is built, the value
+    /// and implicit bytes of an authorization extension, and of every extension
+    /// before it, are excluded from the payload.
+    ///
+    /// This defaults to `false`, which is correct for any extension which doesn't
+    /// authorize the transaction.
+    fn is_authorization_extension(&self) -> bool {
+        false
+    }
+
     /// Given type information for the expected transaction extension,
     /// this should encode the value (ie the bytes that will appear in the
     /// transaction) to the provided `Vec`, or encode nothing and emit an error.
@@ -33,24 +46,6 @@ pub trait TransactionExtension<Resolver: TypeResolver> {
         type_resolver: &Resolver,
         out: &mut Vec<u8>,
     ) -> Result<(), TransactionExtensionError>;
-
-    /// Given type information for the expected transaction extension,
-    /// this should encode the value that will be signed as a part of the
-    /// signer payload.
-    ///
-    /// This defaults to calling [`Self::encode_value_to`] if not implemented.
-    /// In most cases this is fine, but for V5 extrinsics we can optionally provide
-    /// the signature inside a transaction extension, and so that transaction would be
-    /// unable to encode anything for the signer payload and thus should override this
-    /// method to encode nothing.
-    fn encode_value_for_signer_payload_to(
-        &self,
-        type_id: Resolver::TypeId,
-        type_resolver: &Resolver,
-        out: &mut Vec<u8>,
-    ) -> Result<(), TransactionExtensionError> {
-        self.encode_value_to(type_id, type_resolver, out)
-    }
 
     /// Given type information for the expected transaction extension,
     /// this should encode the implicit (ie the bytes that will appear in the

--- a/src/methods/extrinsic_encoder/transaction_extensions.rs
+++ b/src/methods/extrinsic_encoder/transaction_extensions.rs
@@ -25,6 +25,13 @@ pub trait TransactionExtensions<Resolver: TypeResolver> {
     /// Is a given transaction extension contained within this set?
     fn contains_extension(&self, name: &str) -> bool;
 
+    /// Does the named transaction extension authorize the transaction
+    /// (see [`TransactionExtension::is_authorization_extension`])? This should
+    /// return `false` for any extension not contained within this set.
+    fn is_authorization_extension(&self, _name: &str) -> bool {
+        false
+    }
+
     /// This will be called given the name of each transaction extension we
     /// wish to obtain the encoded bytes to. Implementations are expected to
     /// write the bytes that should be included in the **transaction** to the given [`Vec`],
@@ -36,26 +43,6 @@ pub trait TransactionExtensions<Resolver: TypeResolver> {
         type_resolver: &Resolver,
         out: &mut Vec<u8>,
     ) -> Result<(), TransactionExtensionsError>;
-
-    /// This will be called given the name of each transaction extension we
-    /// wish to obtain the encoded bytes to. Implementations are expected to
-    /// write the bytes that should be included in the **signer payload value
-    /// section** to the given [`Vec`], or return an error if no such bytes can be
-    /// written.
-    ///
-    /// This defaults to calling [`Self::encode_extension_value_to`] if not implemented.
-    /// In most cases this is fine, but for V5 extrinsics we can optionally provide
-    /// the signature inside a transaction extension, and so that transaction would be
-    /// unable to encode anything for the signer payload.
-    fn encode_extension_value_for_signer_payload_to(
-        &self,
-        name: &str,
-        type_id: Resolver::TypeId,
-        type_resolver: &Resolver,
-        out: &mut Vec<u8>,
-    ) -> Result<(), TransactionExtensionsError> {
-        self.encode_extension_value_to(name, type_id, type_resolver, out)
-    }
 
     /// This will be called given the name of each transaction extension we
     /// wish to obtain the encoded bytes to. Implementations are expected to
@@ -130,6 +117,15 @@ macro_rules! impl_tuples {
                 false
             }
 
+            fn is_authorization_extension(&self, name: &str) -> bool {
+                $(
+                    if $ident::NAME == name {
+                        return self.$index.is_authorization_extension()
+                    }
+                )*
+                false
+            }
+
             fn encode_extension_value_to(
                 &self,
                 name: &str,
@@ -142,34 +138,6 @@ macro_rules! impl_tuples {
                 $(
                     if $ident::NAME == name {
                         return self.$index.encode_value_to(type_id, type_resolver, out)
-                            .map_err(|e| {
-                                // Protection: if we are returning an error then
-                                // no bytes should have been encoded to the given
-                                // Vec. Ensure that this is true:
-                                out.truncate(len);
-                                TransactionExtensionsError::Other {
-                                    extension_name: name.to_owned(),
-                                    error: e,
-                                }
-                            });
-                    }
-                )*
-
-                Err(TransactionExtensionsError::NotFound(name.to_owned()))
-            }
-
-            fn encode_extension_value_for_signer_payload_to(
-                &self,
-                name: &str,
-                type_id: <Resolver as TypeResolver>::TypeId,
-                type_resolver: &Resolver,
-                out: &mut Vec<u8>
-            ) -> Result<(), TransactionExtensionsError> {
-                let len = out.len();
-
-                $(
-                    if $ident::NAME == name {
-                        return self.$index.encode_value_for_signer_payload_to(type_id, type_resolver, out)
                             .map_err(|e| {
                                 // Protection: if we are returning an error then
                                 // no bytes should have been encoded to the given


### PR DESCRIPTION
## Summary

- Match FRAME V5 signer-payload semantics by keeping the transaction-extension version and call as an immutable base implication.
- Encode explicit and implicit transaction-extension implications separately, allowing authorization extensions such as `VerifyMultiSignature` to discard only preceding extension implications.
- Invoke signer-payload hooks even for zero-sized extensions.
- Change the precomputed-info helper signature to require the transaction-extension version while retaining its existing name.
- Bump `frame-decode` to `0.18.0` for the breaking API change.
- Add a regression test covering a nonzero extension version, zero-sized `VerifyMultiSignature`, and extensions on both sides of the authorization boundary.

## Root cause

The previous V5 implementation accumulated the call, explicit extension values, and implicit extension values into one output buffer. `VerifyMultiSignature` implements FRAME authorization semantics by excluding previously accumulated extension implications. Because the call shared that mutable buffer, applying that boundary also removed the call. In addition, the transaction-extension version was not included in the signer payload.

FRAME treats `(transaction_extension_version, call)` as `TxBaseImplication`. That base must always remain signed. Only explicit and implicit implications from extensions before an authorization extension may be discarded, and those two implication sections are independent.

The resulting V5 preimage is equivalent to:

```text
SCALE(transaction_extension_version)
  || SCALE(call)
  || SCALE(explicit implications after VerifyMultiSignature)
  || SCALE(implicit implications after VerifyMultiSignature)
```

The signer signs `blake2_256(preimage)`.

## Specification and reference implementations

Normative FRAME references:

- [Transaction-extension pipelines, inherited implications, and authorized origins](https://paritytech.github.io/polkadot-sdk/master/sp_runtime/traits/transaction_extension/trait.TransactionExtension.html#pipelines-inherited-implications-and-authorized-origins) describe how an authorization extension receives the implications of the call and the extensions that follow it.
- [`DispatchTransaction::validate_only`](https://github.com/paritytech/polkadot-sdk/blob/45f8331013e6ee2880cf1b4fd22e6676ab14ed23/substrate/primitives/runtime/src/traits/transaction_extension/dispatch_transaction.rs#L99-L115) constructs the initial implication as `TxBaseImplication((extension_version, call))`.
- [`TxBaseImplication` and `ImplicationParts`](https://github.com/paritytech/polkadot-sdk/blob/45f8331013e6ee2880cf1b4fd22e6676ab14ed23/substrate/primitives/runtime/src/traits/transaction_extension/mod.rs#L52-L94) define independent `base`, `explicit`, and `implicit` sections.
- [`VerifyMultiSignature::validate`](https://github.com/paritytech/polkadot-sdk/blob/45f8331013e6ee2880cf1b4fd22e6676ab14ed23/substrate/frame/verify-signature/src/extension.rs#L138-L153) states that preceding extensions are excluded, following extensions are included, and verifies `blake2_256(inherited_implication)`.
- [FRAME authorization-extension tests](https://github.com/paritytech/polkadot-sdk/blob/45f8331013e6ee2880cf1b4fd22e6676ab14ed23/substrate/frame/examples/authorization-tx-extension/src/tests.rs#L148-L167) construct and successfully dispatch a signature over `((extension_version, call), following extensions, following implicits)`.

PAPI `main` cross-check at [`d479106`](https://github.com/polkadot-api/polkadot-api/tree/d479106524f56e7dfaf3251c2572da81fcba6d33):

- Its [extrinsic-format codec](https://github.com/polkadot-api/polkadot-api/blob/d479106524f56e7dfaf3251c2572da81fcba6d33/packages/substrate-bindings/src/extrinsics/extrinsic-format.ts#L12-L26) and [codec tests](https://github.com/polkadot-api/polkadot-api/blob/d479106524f56e7dfaf3251c2572da81fcba6d33/packages/substrate-bindings/tests/extrinsics/extrinsics.spec.ts#L35-L60) confirm that V5 uses bare or general format, with general encoded as `0x45`.
- Its [V5 general decoder](https://github.com/polkadot-api/polkadot-api/blob/d479106524f56e7dfaf3251c2572da81fcba6d33/packages/tx-utils/src/decode-extrinsic.ts#L86-L122) reads the extension-version byte immediately after the format byte and, for metadata V16, selects `signedExtensions[extensionVersion]`. This corroborates the version placement and versioned extension-set selection used here.
- PAPI `main` does not currently provide an independent reference for the V5 signer implication: its bundled [raw signer](https://github.com/polkadot-api/polkadot-api/blob/d479106524f56e7dfaf3251c2572da81fcba6d33/packages/signers/signer/src/from-raw-signer.ts#L30-L43) returns `createV4Tx`, and its [`getTxHelper` signing path](https://github.com/polkadot-api/polkadot-api/blob/d479106524f56e7dfaf3251c2572da81fcba6d33/packages/tx-utils/src/new-helper.ts#L225-L255) explicitly requires extrinsic V4. The FRAME references above therefore remain the conformance target for the V5 signature hash.

polkadot-app-ios-v2 production cross-check:

- The app's [top-level dependency lock](https://github.com/paritytech/polkadot-app-ios-v2/blob/67cb835fee6f676d3b97c1b89b978ac324b2aafe/polkadot-app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved#L356-L362) pins `substrate-sdk-ios 5.9.4` at `7b01e9c`, and its [extrinsic-version provider](https://github.com/paritytech/polkadot-app-ios-v2/blob/67cb835fee6f676d3b97c1b89b978ac324b2aafe/polkadot-app/Common/Services/Extrinsic/ExtrinsicVersionProvider.swift#L11-L17) selects V5 with extension version 0 for the username chain.
- At that exact SDK revision, the [builder starts with a call-only implication and folds metadata extensions in reverse](https://github.com/novasamatech/substrate-sdk-ios/blob/7b01e9ce9f0075a2ac7e9f7c7d8c3a5ee22c97e1/SubstrateSdk/Classes/Extrinsic/ExtrinsicBuilder.swift#L235-L280). Each extension receives the accumulated implication before its own explicit and implicit values are prepended. Consequently, `VerifyMultiSignature` receives the call plus only extensions that follow it.
- The SDK's [V5 implication payload factory](https://github.com/novasamatech/substrate-sdk-ios/blob/7b01e9ce9f0075a2ac7e9f7c7d8c3a5ee22c97e1/SubstrateSdk/Classes/Extrinsic/ImplicationSignaturePayloadFactory.swift#L40-L64) independently encodes `extension_version || call || explicits || implicits`. [`VerifyMultiSignature` hashes that inherited implication with `blake2b32`](https://github.com/novasamatech/substrate-sdk-ios/blob/7b01e9ce9f0075a2ac7e9f7c7d8c3a5ee22c97e1/SubstrateSdk/Classes/Extrinsic/TransactionExtension/Extensions/VerifySignature.swift#L89-L112), whose [implementation requests a 32-byte Blake2b digest](https://github.com/novasamatech/substrate-sdk-ios/blob/7b01e9ce9f0075a2ac7e9f7c7d8c3a5ee22c97e1/SubstrateSdk/Classes/Primitives/Data%2BHash.swift#L42-L52). This matches the preimage and authorization boundary implemented here.
- The SDK's [V5 integration test](https://github.com/novasamatech/substrate-sdk-ios/blob/7b01e9ce9f0075a2ac7e9f7c7d8c3a5ee22c97e1/Tests/ExtrinsicBuilder/ExtrinsicBuilderV5Tests.swift#L8-L64) exercises signing, encoding, and decoding a V5 transfer. It is useful integration coverage, but it does not assert a fixed signer-payload vector or runtime acceptance; FRAME and this PR's focused regression test remain the conformance oracle.

## Breaking API change

`encode_v5_signer_payload` already receives the transaction-extension version and now includes it correctly.

`encode_v5_signer_payload_with_info` retains its existing name and now requires `transaction_extension_version` as its second argument. This is an intentional breaking signature change because the previous signature could not produce a correct V5 payload for nonzero extension versions.

The crate version is bumped to `0.18.0`. Downstream users, including Subxt, must deliberately update their `frame-decode` dependency range before consuming this release.

## Validation

Local validation:

- `cargo fmt --all -- --check`
- `cargo check --all-features --workspace --lib --bins --examples`
- no-default-feature checks with no features and with `legacy,error-tracing`
- `wasm32-unknown-unknown` compatibility check
- `aarch64-unknown-none` no-std check
- `cargo clippy --all-targets -- -D warnings`
- strict rustdoc broken-link check
- `cargo test --all-targets --workspace --features legacy-types`
- workspace doctests and example tests
- downstream TrUAPI validation against local `frame-decode 0.18.0` through Subxt: all 434 `truapi-server` tests and integration tests pass
- direct and paired TrUAPI CLI `CreateTransaction` checks forced to transaction version 5; both produced V5 general extrinsics (`0x45 00` inner prefix)

All required GitHub CI and security checks pass for commit `ee8acb5`.

## Downstream pull requests

- paritytech/subxt#2268 updates Subxt to consume the corrected frame-decode API.
- paritytech/truapi#333 integrates the complete stack and exercises V4 and V5 transaction creation.

Merge and publication order is frame-decode, then Subxt, then TrUAPI.

## Release-version blocker

The crates.io index already contains a yanked `frame-decode 0.18.0`. Published crate versions are immutable, so this corrected release cannot be uploaded under 0.18.0. The draft needs a follow-up version decision before merge; for a pre-1.0 breaking API change, the next available minor is 0.19.0.