### PR TITLE
Release 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-## 0.18.0 (2026-08-06)
+## 0.18.1 (2026-08-06)
+
+Note: `0.18.0` was published to crates.io by accident and yanked; this release takes its place.
 
 - Fix V5 signer payloads to hash the transaction extension version and call, followed by the extension values and implicits of only the extensions after the last authorization extension (such as `VerifyMultiSignature`), matching FRAME's transaction extension pipeline semantics.
 - Add `TransactionExtension::is_authorization_extension` (and the corresponding `TransactionExtensions` method), which extensions like `VerifyMultiSignature` should override to return `true`. It defaults to `false`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "frame-metadata 23.0.1",
  "hex",
@@ -811,7 +811,7 @@ dependencies = [
 name = "frame-decode-tester"
 version = "0.1.0"
 dependencies = [
- "frame-decode 0.18.0",
+ "frame-decode 0.18.1",
  "frame-metadata 23.0.1",
  "hex",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frame-decode"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 description = "Decode extrinsics and storage from Substrate based chains"
 license = "Apache-2.0"


### PR DESCRIPTION
Bump to `0.18.1` for release.

`0.18.0` was published to crates.io by accident back in February (before #104 and #106 landed) and then yanked, so crates.io permanently refuses that version number. The release that was prepped as `0.18.0` therefore goes out as `0.18.1` instead.

- `Cargo.toml`/`Cargo.lock`: `0.18.0` -> `0.18.1`
- `CHANGELOG.md`: rename the `0.18.0` section and note why the number was skipped

No code changes; contents are identical to what was prepped in #106.